### PR TITLE
Untested patch for bug in 2018 SCEC benchmark dmu/dV, dmu/dtheta

### DIFF
--- a/src/friction.f90
+++ b/src/friction.f90
@@ -65,7 +65,7 @@ function friction_mu(v,theta,pb) result(mu)
     mu = pb%mu_star - pb%a*log(pb%v1/v+1d0) + pb%b*log(theta/pb%theta_star+1d0)
 
   case (2) ! SCEC 2018 benchmark
-    mu = pb%a*asinh( v/(2*pb%v_star)*exp( (pb%mu_star + pb%b*log(theta/pb%theta_star))/pb%a ) )  
+    mu = pb%a*asinh( v/(2*pb%v_star)*exp( (pb%mu_star + pb%b*log(theta/pb%theta_star))/pb%a ) )
 
   case (3) ! SEISMIC: CNS model
     write (6,*) "friction.f90::friction_mu is deprecated for the CNS model"
@@ -140,12 +140,12 @@ subroutine dmu_dv_dtheta(dmu_dv,dmu_dtheta,v,tau,sigma,theta,theta2,pb)
   case(1)
     dmu_dtheta = pb%b * pb%v2 / ( pb%v2*theta + pb%dc )
     dmu_dv = pb%a * pb%v1 / v / ( pb%v1 + v )
-  
+
   case(2) ! 2018 SCEC Benchmark
-    z = v/(2*pb%v_star)*exp( (pb%mu_star + pb%b*log(theta/pb%theta_star))/pb%a )
-    dmu_dtheta = pb%b*v/(2*theta*pb%v_star)/sqrt(1 + z**2)*exp( (pb%mu_star + pb%b*log(theta/pb%theta_star))/pb%a )
-    dmu_dv = pb%a/sqrt(1 + z**2)*exp( (pb%mu_star + pb%b*log(theta/pb%theta_star))/pb%a )/(2*pb%v_star)
- 
+    z = exp(pb%mu_star + pb%b * log(theta/pb%theta_star) / pb%a) / (2*pb%v_star)
+    dmu_dv = pb%a / sqrt(1.0/z**2 + v**2)
+    dmu_dtheta = dmu_dv * (pb%b*v) / (pb%a*theta)
+
   case(3) ! SEISMIC: CNS model
     write (6,*) "friction.f90::dmu_dv_dtheta is deprecated for the CNS model"
     stop

--- a/src/friction.f90
+++ b/src/friction.f90
@@ -142,7 +142,7 @@ subroutine dmu_dv_dtheta(dmu_dv,dmu_dtheta,v,tau,sigma,theta,theta2,pb)
     dmu_dv = pb%a * pb%v1 / v / ( pb%v1 + v )
 
   case(2) ! 2018 SCEC Benchmark
-    z = exp(pb%mu_star + pb%b * log(theta/pb%theta_star) / pb%a) / (2*pb%v_star)
+    z = exp((pb%mu_star + pb%b * log(theta/pb%theta_star)) / pb%a) / (2*pb%v_star)
     dmu_dv = pb%a / sqrt(1.0/z**2 + v**2)
     dmu_dtheta = dmu_dv * (pb%b*v) / (pb%a*theta)
 


### PR DESCRIPTION
In the original code, `dmu_dv` and `dmu_dtheta` would often be set to zero due to numerical instability (division of two large floats), and would not converge to `a/V` and `b/theta` for `z >> 1` (`z` could easily reach `1e+300` close to steady-state). This potential bug would go unnoticed when radiation damping is turned on (zero `dmu_dV` is offset by `eta`), but would produce incorrect results. I don't know if my alternative form is correct, I have never worked with the regularised rate-and-state formulations. Please verify and rebase if you agree with the proposed changes.