### PR TITLE
QDYN release 2.3.1

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,13 +12,13 @@ title: Getting started
 
 - MPI (e.g. [MPICH](https://www.mpich.org/) or [Open MPI](https://www.open-mpi.org/)) linked to your Fortran compiler (`mpif90`)
 
-- Python 3+, MATLAB, or Octave. The Python wrapper relies on [NumPy](http://www.numpy.org/) and [Pandas](https://pandas.pydata.org/). The Python test suite (optional but recommended for developers) additionally requires [matplotlib](https://matplotlib.org/) and [termcolor](https://pypi.org/project/termcolor/). These dependencies are conveniently acquired through [`pip`](https://pypi.org/project/pip/):<br />
+- Python 3+, MATLAB, or Octave. The Python wrapper relies on [NumPy](http://www.numpy.org/)/[SciPy](https://scipy.org/) and [Pandas](https://pandas.pydata.org/). The Python test suite (optional but recommended for developers) additionally requires [matplotlib](https://matplotlib.org/) and [termcolor](https://pypi.org/project/termcolor/). These dependencies are conveniently acquired through [`pip`](https://pypi.org/project/pip/):<br />
   ```
-  pip install numpy pandas matplotlib termcolor
+  pip install numpy scipy pandas matplotlib termcolor
   ```
   or through [Anaconda](https://www.anaconda.com/):<br />
   ```
-  conda create -n QDYN python=3.7 numpy matplotlib pandas termcolor
+  conda create -n QDYN python=3.7 numpy scipy matplotlib pandas termcolor
   conda activate QDYN
   ```
 

--- a/docs/running_simulations.md
+++ b/docs/running_simulations.md
@@ -233,6 +233,7 @@ QDYN offers various optional simulation features. Set the following parameters t
 |   `NX`    | Number of fault elements along strike if `MESHDIM=2`. It must be a power of 2 if FFT is used along strike (`FFT_TYPE=1` in `constants.f90`) |      `1`      |
 |   `NW`    | Number of fault elements along dip if `MESHDIM=2`. It must be a power of 2 if FFT is used along dip (`FFT_TYPE=2` in `constants.f90`) |     `-1`      |
 | `NPROCS`  | Number of processors if running in parallel and with MPI (only implemented for `MESHDIM=2` and `FFT_TYPE=1`) |      `1`      |
+| `MPI_PATH`  | Full path to the MPI binary (`which mpirun`). For WSL, this path is likely `/usr/bin/mpirun` |      `/usr/local/bin/mpirun`      |
 |   `DW`    | Along-dip length (m) of each element, from deep to shallow   |      `1`      |
 |  `TMAX`   | Threshold for stopping criterion:<br />Final simulation time (s) when `NSTOP=0`<br />Slip velocity threshold (m/s) when `NSTOP=3` |               |
 |  `NSTOP`  | Stopping criterion:<br />`0` = Stop at `t = TMAX`<br />`1` = Stop at end of slip localization phase (**deprecated**)<br />`2` = Stop soon after first slip rate peak<br />`3` = Stop when slip velocity exceeds `TMAX` (m/s) |      `0`      |

--- a/docs/tutorial_double_asperity_python.md
+++ b/docs/tutorial_double_asperity_python.md
@@ -149,7 +149,7 @@ For this tutorial, we will use an auxiliary library of functions (`plot_function
 
 ```python
 # Time series of stress, state, and maximum slip rate on the fault
-qdyn_plot.timeseries(p.ot[0])
+qdyn_plot.timeseries(p.ot[0], p.ot_vmax)
 ```
 
 ![](img/tutorials/double_asperity/timeseries.png)

--- a/docs/tutorial_single_asperity_python.md
+++ b/docs/tutorial_single_asperity_python.md
@@ -149,7 +149,7 @@ For this tutorial, we will use an auxiliary library of functions (`plot_function
 
 ```python
 # Time series of stress, state, and maximum slip rate on the fault
-qdyn_plot.timeseries(p.ot[0])
+qdyn_plot.timeseries(p.ot[0], p.ot_vmax)
 ```
 
 ![](img/tutorials/single_asperity/timeseries.png)

--- a/examples/notebooks/double_asperity.ipynb
+++ b/examples/notebooks/double_asperity.ipynb
@@ -1817,7 +1817,7 @@
    ],
    "source": [
     "# Time series of stress, state, and maximum slip rate on the fault\n",
-    "qdyn_plot.timeseries(p.ot[0])"
+    "qdyn_plot.timeseries(p.ot[0], p.ot_vmax)"
    ]
   },
   {

--- a/examples/notebooks/single_asperity.ipynb
+++ b/examples/notebooks/single_asperity.ipynb
@@ -1824,7 +1824,7 @@
    ],
    "source": [
     "# Time series of stress, state, and maximum slip rate on the fault\n",
-    "qdyn_plot.timeseries(p.ot[0])"
+    "qdyn_plot.timeseries(p.ot[0], p.ot_vmax)"
    ]
   },
   {

--- a/src/constants.f90
+++ b/src/constants.f90
@@ -52,6 +52,9 @@ integer :: FAULT_TYPE = 0
 !   2 : Runge-Kutta-Fehlberg
 integer :: SOLVER_TYPE = 0
 
+! Input unit
+integer, parameter :: FID_IN = 15
+
 ! Output units
 integer, parameter :: FID_SCREEN = 6
 integer, parameter :: FID_OT = 18

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -74,6 +74,7 @@ subroutine init_all(pb)
   ! SEISMIC: initialise pb%tau in input.f90 to be compatible with CNS model
   allocate ( pb%dtau_dt(n), pb%slip(n), pb%theta_star(n) )
   pb%slip = 0d0
+  pb%dtau_dt = 0d0
   call set_theta_star(pb)
 
   ! SEISMIC: initialise thermal pressurisation model (diffusion_solver.f90)

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -136,7 +136,7 @@ subroutine init_mesh_1D(m)
   integer :: i
 
   write(6,*) '1D fault, uniform grid'
-  allocate(m%dx(1), m%dw(1))
+  allocate(m%dx(m%nn), m%dw(1))
   m%nx = m%nn
   m%nw = 1
   m%dx = m%Lfault/m%nn
@@ -178,7 +178,7 @@ subroutine init_mesh_2D(m)
 
   write(6,*) '2D fault, uniform grid along-strike'
 
-  allocate(m%dx(1))
+  allocate(m%dx(m%nx))
 
 if (.not.is_MPI_parallel()) then
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -5,7 +5,7 @@ module mesh
 
   type mesh_type
     integer :: dim = 0  ! dim = 1, 2 ,3 ~xD
-    integer :: nx, nw, nn, nnglob, nwglob ! along-strike, along-dip, total grid number
+    integer :: nx, nw, nn, nnglob, nwglob, nxglob ! along-strike, along-dip, total grid number
     double precision :: Lfault, W, Z_CORNER ! fault length, width, lower-left corner z (follow Okada's convention)
     double precision, allocatable :: DIP_W(:) ! along-dip grid size and dip (adjustable), nw count
     ! Local mesh coordinates
@@ -119,6 +119,8 @@ subroutine init_mesh_0D(m)
   allocate(m%dx(1), m%dw(1))
   m%nx = 1
   m%nw = 1
+  m%nxglob = m%nx
+  m%nwglob = m%nw
   m%dx = m%Lfault
   m%dw = 1d0
   m%x = 0d0
@@ -154,6 +156,8 @@ subroutine init_mesh_1D(m)
   m%xglob => m%x
   m%yglob => m%y
   m%zglob => m%z
+  m%nxglob = m%nx
+  m%nwglob = m%nw
 
 end subroutine init_mesh_1D
 
@@ -168,6 +172,7 @@ subroutine init_mesh_2D(m)
 
   use constants, only : PI
   use my_mpi, only: is_MPI_parallel, my_mpi_NPROCS, gather_alli, gather_allvdouble, my_mpi_tag
+  use my_mpi, only: is_MPI_master
 
   type(mesh_type), intent(inout) :: m
 
@@ -205,7 +210,6 @@ if (.not.is_MPI_parallel()) then
     m%x(j0+1:j0+m%nx) = m%x(1:m%nx)
     m%y(j0+1:j0+m%nx) = m%y(j0) + 0.5d0*m%dw(i-1)*cd0 + 0.5d0*m%dw(i)*cd
     m%z(j0+1:j0+m%nx) = m%z(j0) + 0.5d0*m%dw(i-1)*sd0 + 0.5d0*m%dw(i)*sd
-!    write(66,*) m%z(j0+1:j0+m%nx) !JPA Who is using this output? Shall we remove it?
     m%dip(j0+1:j0+m%nx) = m%DIP_W(i)
   end do
 
@@ -215,6 +219,7 @@ if (.not.is_MPI_parallel()) then
     m%dipglob => m%dip
     m%dwglob => m%dw
     m%nwglob = m%nw
+    m%nxglob = m%nx
 
 else
 ! If MPI parallel, the mesh for each processor has been already read
@@ -224,7 +229,7 @@ else
     NPROCS = my_mpi_NPROCS()
 !PG, for debugging:
     nwLocal = m%nw
-    write(6,*) 'iproc,nwLocal:',my_mpi_tag(),nwLocal
+    ! write(6,*) 'iproc,nwLocal:',my_mpi_tag(),nwLocal
     allocate(nwLocal_perproc(0:NPROCS-1))
     call gather_alli(nwLocal,nwLocal_perproc)
     allocate(nwoffset_glob_perproc(0:NPROCS-1))
@@ -232,8 +237,9 @@ else
       nwoffset_glob_perproc(iproc)=sum(nwLocal_perproc(0:iproc))-nwLocal_perproc(iproc)
     enddo
     nwGlobal=sum(nwLocal_perproc)
+    m%nxglob = m%nx
     m%nwglob = nwGlobal
-    write(6,*) 'iproc,nwGlobal:',my_mpi_tag(),nwGlobal
+    ! write(6,*) 'iproc,nwGlobal:',my_mpi_tag(),nwGlobal
 
     nnLocal= m%nx*nwLocal
     allocate(nnLocal_perproc(0:NPROCS-1))
@@ -246,6 +252,7 @@ else
    ! global mesh for computing the kernel and for outputs
     allocate(m%xglob(nnGlobal),m%yglob(nnGlobal),&
              m%zglob(nnGlobal),m%dwglob(nwGlobal),m%dipglob(nnGlobal))
+
     call gather_allvdouble(m%x, nnLocal,m%xglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)
     call gather_allvdouble(m%y, nnLocal,m%yglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)
     call gather_allvdouble(m%z, nnLocal,m%zglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)

--- a/src/output.f90
+++ b/src/output.f90
@@ -921,6 +921,7 @@ subroutine calc_potency(pb)
 
   pb%pot = 0d0
   pb%pot_rate = 0d0
+  area = 0d0
 
   ! Step 1: define area vector
   do iw=1, pb%mesh%nw

--- a/src/parallel.f90
+++ b/src/parallel.f90
@@ -27,6 +27,9 @@ subroutine init_mpi()
   integer :: ier
 
   call MPI_INIT(ier)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, NPROCS, ier)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, MY_RANK, ier)
+
   if (ier /= 0 ) stop 'Error initializing MPI'
 
   if (NPROCS<2) call MPI_FINALIZE(ier)

--- a/src/pyqdyn.py
+++ b/src/pyqdyn.py
@@ -498,7 +498,7 @@ class qdyn:
 
         else: # MPI parallel
 
-            MPI_path = self.set_dict["MPI_path"]
+            MPI_path = self.set_dict["MPI_PATH"]
 
             # If we're on a Windows 10 + Unix subsystem, call bash
             if self.W10_bash is True:

--- a/src/pyqdyn.py
+++ b/src/pyqdyn.py
@@ -196,7 +196,7 @@ class qdyn:
         set_dict["DYN_M"] = 1e18			# Target seismic moment of dynamic event
 
         set_dict["NPROC"] = 1				# Number of processors, default 1 = serial (no MPI)
-        set_dict["MPI_path"] = "/usr/local/bin/mpirun"   # Path to MPI executable
+        set_dict["MPI_PATH"] = "/usr/local/bin/mpirun"   # Path to MPI executable
 
         self.set_dict = set_dict
 
@@ -303,12 +303,18 @@ class qdyn:
             mesh_dict["Y"] = np.ones(N)*settings["W"]
 
         if dim == 2:
+
             print("Warning: 2D faults currently require constant dip angle")
-            theta = settings["DIP_W"]*np.pi/180.0
-            mesh_dict["DW"] = np.ones(settings["NW"])*settings["DW"]
-            mesh_dict["DIP_W"] = np.ones(N)*settings["DIP_W"]
-            mesh_dict["X"] = (np.arange(N) % settings["NX"] + 0.5)*dx
-            mesh_dict["Y"] = (np.floor(np.arange(N)/settings["NX"]) + 0.5)*settings["DW"]*np.cos(theta)
+
+            dw = settings["W"] / settings["NW"]
+            theta = settings["DIP_W"] * np.pi / 180.0
+            mesh_dict["DIP_W"] = np.ones(N) * settings["DIP_W"]
+            mesh_dict["DW"] = np.ones(N) * dw
+            x = (np.arange(settings["NX"]) + 0.5) * dx
+            y = (np.arange(settings["NW"]) + 0.5) * dw * np.cos(theta)
+            X, Y = np.meshgrid(x, y, indexing="xy")
+            mesh_dict["X"] = X.ravel()
+            mesh_dict["Y"] = Y.ravel()
             mesh_dict["Z"] = settings["Z_CORNER"] + mesh_dict["Y"]*np.tan(theta)
 
         self.mesh_dict.update(mesh_dict)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -20,9 +20,12 @@ contains
 subroutine solve(pb)
 
   use output, only : write_output
-  use my_mpi, only : is_MPI_parallel, finalize_mpi
+  use my_mpi, only : is_MPI_parallel, finalize_mpi, synchronize_all
 
   type(problem_type), intent(inout)  :: pb
+
+  ! Synchronise all processes
+  if (is_MPI_parallel()) call synchronize_all()
 
   ! Before the first step, update field and write output (initial state)
   call update_field(pb)

--- a/utils/post_processing/plot_functions.py
+++ b/utils/post_processing/plot_functions.py
@@ -9,7 +9,7 @@ t_year = 365 * t_day
 figsize = (9, 8)
 
 
-def timeseries(ot):
+def timeseries(ot, ot_vmax):
 
     fig, axes = plt.subplots(nrows=3, ncols=1, figsize=figsize)
 
@@ -19,7 +19,7 @@ def timeseries(ot):
     axes[1].plot(ot["t"] / t_year, ot["theta"])
     axes[1].set_ylabel("state [s]")
 
-    axes[2].plot(ot["t"] / t_year, ot["v_max"])
+    axes[2].plot(ot_vmax["t"] / t_year, ot_vmax["v_max"])
     axes[2].set_ylabel("max v [m/s]")
     axes[2].set_xlabel("time [yr]")
     axes[2].set_yscale("log")


### PR DESCRIPTION
# What's new in version 2.3.1?

## Documentation

- Added SciPy as a requirement to the documentation
- Added documentation for the `MPI_PATH` variable

## Bug fixes

- Updated tutorials to correctly plot vmax time series
- Fixed MPI initialisation bugs introduced by release 2.3.0
- Fixed a couple of issues in the new output modules in relation to MPI
- Modified the 2D mesh generation function in the `pyqdyn.py` wrapper
- Properly initialised the stressing rate (`dtau_dt`) to prevent NaNs in the output