### PR TITLE
Fixed initialisation bug in calculating potency (rate)

### DIFF
--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -74,6 +74,7 @@ subroutine init_all(pb)
   ! SEISMIC: initialise pb%tau in input.f90 to be compatible with CNS model
   allocate ( pb%dtau_dt(n), pb%slip(n), pb%theta_star(n) )
   pb%slip = 0d0
+  pb%dtau_dt = 0d0
   call set_theta_star(pb)
 
   ! SEISMIC: initialise thermal pressurisation model (diffusion_solver.f90)

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -136,7 +136,7 @@ subroutine init_mesh_1D(m)
   integer :: i
 
   write(6,*) '1D fault, uniform grid'
-  allocate(m%dx(1), m%dw(1))
+  allocate(m%dx(m%nn), m%dw(1))
   m%nx = m%nn
   m%nw = 1
   m%dx = m%Lfault/m%nn
@@ -178,7 +178,7 @@ subroutine init_mesh_2D(m)
 
   write(6,*) '2D fault, uniform grid along-strike'
 
-  allocate(m%dx(1))
+  allocate(m%dx(m%nx))
 
 if (.not.is_MPI_parallel()) then
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -522,7 +522,6 @@ subroutine ot_write(pb)
     call get_ivmax(pb)
     ivmax = pb%ivmax
     ! Calculate potency (rate)
-    write(6, *) "Calcing potency"
     call calc_potency(pb)
 
     ! Number of OT locations

--- a/src/output.f90
+++ b/src/output.f90
@@ -522,6 +522,7 @@ subroutine ot_write(pb)
     call get_ivmax(pb)
     ivmax = pb%ivmax
     ! Calculate potency (rate)
+    write(6, *) "Calcing potency"
     call calc_potency(pb)
 
     ! Number of OT locations
@@ -921,6 +922,7 @@ subroutine calc_potency(pb)
 
   pb%pot = 0d0
   pb%pot_rate = 0d0
+  area = 0d0
 
   ! Step 1: define area vector
   do iw=1, pb%mesh%nw


### PR DESCRIPTION
The mesh element spacing was not properly initialised for 1D faults, resulting in NaNs when calculating the potency (rate).