### PR TITLE
Various fixes for MPI simulations

### DIFF
--- a/docs/running_simulations.md
+++ b/docs/running_simulations.md
@@ -233,6 +233,7 @@ QDYN offers various optional simulation features. Set the following parameters t
 |   `NX`    | Number of fault elements along strike if `MESHDIM=2`. It must be a power of 2 if FFT is used along strike (`FFT_TYPE=1` in `constants.f90`) |      `1`      |
 |   `NW`    | Number of fault elements along dip if `MESHDIM=2`. It must be a power of 2 if FFT is used along dip (`FFT_TYPE=2` in `constants.f90`) |     `-1`      |
 | `NPROCS`  | Number of processors if running in parallel and with MPI (only implemented for `MESHDIM=2` and `FFT_TYPE=1`) |      `1`      |
+| `MPI_PATH`  | Full path to the MPI binary (`which mpirun`). For WSL, this path is likely `/usr/bin/mpirun` |      `/usr/local/bin/mpirun`      |
 |   `DW`    | Along-dip length (m) of each element, from deep to shallow   |      `1`      |
 |  `TMAX`   | Threshold for stopping criterion:<br />Final simulation time (s) when `NSTOP=0`<br />Slip velocity threshold (m/s) when `NSTOP=3` |               |
 |  `NSTOP`  | Stopping criterion:<br />`0` = Stop at `t = TMAX`<br />`1` = Stop at end of slip localization phase (**deprecated**)<br />`2` = Stop soon after first slip rate peak<br />`3` = Stop when slip velocity exceeds `TMAX` (m/s) |      `0`      |

--- a/src/constants.f90
+++ b/src/constants.f90
@@ -52,6 +52,9 @@ integer :: FAULT_TYPE = 0
 !   2 : Runge-Kutta-Fehlberg
 integer :: SOLVER_TYPE = 0
 
+! Input unit
+integer, parameter :: FID_IN = 15
+
 ! Output units
 integer, parameter :: FID_SCREEN = 6
 integer, parameter :: FID_OT = 18

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -224,7 +224,7 @@ else
     NPROCS = my_mpi_NPROCS()
 !PG, for debugging:
     nwLocal = m%nw
-    write(6,*) 'iproc,nwLocal:',my_mpi_tag(),nwLocal
+    ! write(6,*) 'iproc,nwLocal:',my_mpi_tag(),nwLocal
     allocate(nwLocal_perproc(0:NPROCS-1))
     call gather_alli(nwLocal,nwLocal_perproc)
     allocate(nwoffset_glob_perproc(0:NPROCS-1))
@@ -233,7 +233,7 @@ else
     enddo
     nwGlobal=sum(nwLocal_perproc)
     m%nwglob = nwGlobal
-    write(6,*) 'iproc,nwGlobal:',my_mpi_tag(),nwGlobal
+    ! write(6,*) 'iproc,nwGlobal:',my_mpi_tag(),nwGlobal
 
     nnLocal= m%nx*nwLocal
     allocate(nnLocal_perproc(0:NPROCS-1))
@@ -243,9 +243,13 @@ else
     nnGlobal=nwGlobal*m%nx
     m%nnglob = nnGlobal
 
+    allocate( m%x(nnLocal), m%y(nnLocal), m%z(nnLocal), &
+              m%dw(nnLocal), m%dip(nnLocal))
+
    ! global mesh for computing the kernel and for outputs
     allocate(m%xglob(nnGlobal),m%yglob(nnGlobal),&
              m%zglob(nnGlobal),m%dwglob(nwGlobal),m%dipglob(nnGlobal))
+
     call gather_allvdouble(m%x, nnLocal,m%xglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)
     call gather_allvdouble(m%y, nnLocal,m%yglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)
     call gather_allvdouble(m%z, nnLocal,m%zglob,nnLocal_perproc,nnoffset_glob_perproc,nnGlobal)

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -119,6 +119,8 @@ subroutine init_mesh_0D(m)
   allocate(m%dx(1), m%dw(1))
   m%nx = 1
   m%nw = 1
+  m%nxglob = m%nx
+  m%nwglob = m%nw
   m%dx = m%Lfault
   m%dw = 1d0
   m%x = 0d0
@@ -154,6 +156,8 @@ subroutine init_mesh_1D(m)
   m%xglob => m%x
   m%yglob => m%y
   m%zglob => m%z
+  m%nxglob = m%nx
+  m%nwglob = m%nw
 
 end subroutine init_mesh_1D
 
@@ -215,6 +219,7 @@ if (.not.is_MPI_parallel()) then
     m%dipglob => m%dip
     m%dwglob => m%dw
     m%nwglob = m%nw
+    m%nxglob = m%nx
 
 else
 ! If MPI parallel, the mesh for each processor has been already read

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -5,7 +5,7 @@ module mesh
 
   type mesh_type
     integer :: dim = 0  ! dim = 1, 2 ,3 ~xD
-    integer :: nx, nw, nn, nnglob, nwglob ! along-strike, along-dip, total grid number
+    integer :: nx, nw, nn, nnglob, nwglob, nxglob ! along-strike, along-dip, total grid number
     double precision :: Lfault, W, Z_CORNER ! fault length, width, lower-left corner z (follow Okada's convention)
     double precision, allocatable :: DIP_W(:) ! along-dip grid size and dip (adjustable), nw count
     ! Local mesh coordinates
@@ -168,6 +168,7 @@ subroutine init_mesh_2D(m)
 
   use constants, only : PI
   use my_mpi, only: is_MPI_parallel, my_mpi_NPROCS, gather_alli, gather_allvdouble, my_mpi_tag
+  use my_mpi, only: is_MPI_master
 
   type(mesh_type), intent(inout) :: m
 
@@ -205,7 +206,6 @@ if (.not.is_MPI_parallel()) then
     m%x(j0+1:j0+m%nx) = m%x(1:m%nx)
     m%y(j0+1:j0+m%nx) = m%y(j0) + 0.5d0*m%dw(i-1)*cd0 + 0.5d0*m%dw(i)*cd
     m%z(j0+1:j0+m%nx) = m%z(j0) + 0.5d0*m%dw(i-1)*sd0 + 0.5d0*m%dw(i)*sd
-!    write(66,*) m%z(j0+1:j0+m%nx) !JPA Who is using this output? Shall we remove it?
     m%dip(j0+1:j0+m%nx) = m%DIP_W(i)
   end do
 
@@ -232,6 +232,7 @@ else
       nwoffset_glob_perproc(iproc)=sum(nwLocal_perproc(0:iproc))-nwLocal_perproc(iproc)
     enddo
     nwGlobal=sum(nwLocal_perproc)
+    m%nxglob = m%nx
     m%nwglob = nwGlobal
     ! write(6,*) 'iproc,nwGlobal:',my_mpi_tag(),nwGlobal
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -243,9 +243,6 @@ else
     nnGlobal=nwGlobal*m%nx
     m%nnglob = nnGlobal
 
-    allocate( m%x(nnLocal), m%y(nnLocal), m%z(nnLocal), &
-              m%dw(nnLocal), m%dip(nnLocal))
-
    ! global mesh for computing the kernel and for outputs
     allocate(m%xglob(nnGlobal),m%yglob(nnGlobal),&
              m%zglob(nnGlobal),m%dwglob(nwGlobal),m%dipglob(nnGlobal))

--- a/src/output.f90
+++ b/src/output.f90
@@ -256,8 +256,8 @@ subroutine ot_init(pb)
   use problem_class
   use constants, only:  BIN_OUTPUT, FID_IASP, FID_OT, FID_VMAX, &
                         FILE_IASP, FILE_OT, FILE_VMAX
-  use my_mpi, only : is_MPI_parallel, is_MPI_master, gather_allvi_root
-  use mesh, only : mesh_get_size, nnLocal_perproc, nnoffset_glob_perproc
+  use my_mpi, only: is_MPI_parallel, is_MPI_master, gather_allvi_root
+  use mesh, only: mesh_get_size, nnLocal_perproc, nnoffset_glob_perproc
 
   type (problem_type), intent(inout) :: pb
   integer :: i, id, iasp_count, iot_count, n, niasp, niot, nnGlobal
@@ -305,7 +305,7 @@ subroutine ot_init(pb)
   pb%ot%fmt_vmax(2) = "(i15)"
 
   ! If parallel:
-  if (is_MPI_parallel() .and. is_MPI_master()) then
+  if (is_MPI_parallel()) then
     ! Combine local OT indices
     call gather_allvi_root( pb%ot%iot, n, iot_buf, nnLocal_perproc, &
                             nnoffset_glob_perproc, nnGlobal)
@@ -313,7 +313,7 @@ subroutine ot_init(pb)
     call gather_allvi_root( pb%ot%iasp, n, iasp_buf, nnLocal_perproc, &
                             nnoffset_glob_perproc, nnGlobal)
   ! If serial:
-  elseif (.not. is_MPI_parallel()) then
+  else
     ! Point global to local indices
     iot_buf = pb%ot%iot
     iasp_buf = pb%ot%iasp

--- a/src/output.f90
+++ b/src/output.f90
@@ -263,12 +263,9 @@ subroutine ot_init(pb)
   integer :: i, id, iasp_count, iot_count, n, niasp, niot, nnGlobal
   integer, dimension(pb%mesh%nnglob) :: iasp_buf, iot_buf
   integer, allocatable, dimension(:) :: iasp_list, iot_list
-  logical :: call_gather
 
   character(len=100) :: tmp
   character(len=100), allocatable :: iot_name
-
-  call_gather = is_MPI_parallel() .and. is_MPI_master()
 
   ! Number of mesh elements
   n = mesh_get_size(pb%mesh)

--- a/src/output.f90
+++ b/src/output.f90
@@ -877,8 +877,8 @@ subroutine write_ox_lines(unit, fmt, objects, nxout, nwout, pb)
   k = pb%nobj
 
   ! Number of nodes to loop over (either local or global)
-  nx = pb%mesh%nx
-  nw = pb%mesh%nw
+  nx = pb%mesh%nxglob
+  nw = pb%mesh%nwglob
 
   ! Write header
   write(unit,'(a)') trim(pb%ox%header)

--- a/src/parallel.f90
+++ b/src/parallel.f90
@@ -27,6 +27,9 @@ subroutine init_mpi()
   integer :: ier
 
   call MPI_INIT(ier)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, NPROCS, ier)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, MY_RANK, ier)
+
   if (ier /= 0 ) stop 'Error initializing MPI'
 
   if (NPROCS<2) call MPI_FINALIZE(ier)

--- a/src/pyqdyn.py
+++ b/src/pyqdyn.py
@@ -196,7 +196,7 @@ class qdyn:
         set_dict["DYN_M"] = 1e18			# Target seismic moment of dynamic event
 
         set_dict["NPROC"] = 1				# Number of processors, default 1 = serial (no MPI)
-        set_dict["MPI_path"] = "/usr/local/bin/mpirun"   # Path to MPI executable
+        set_dict["MPI_PATH"] = "/usr/local/bin/mpirun"   # Path to MPI executable
 
         self.set_dict = set_dict
 
@@ -303,12 +303,18 @@ class qdyn:
             mesh_dict["Y"] = np.ones(N)*settings["W"]
 
         if dim == 2:
+
             print("Warning: 2D faults currently require constant dip angle")
-            theta = settings["DIP_W"]*np.pi/180.0
-            mesh_dict["DW"] = np.ones(settings["NW"])*settings["DW"]
-            mesh_dict["DIP_W"] = np.ones(N)*settings["DIP_W"]
-            mesh_dict["X"] = (np.arange(N) % settings["NX"] + 0.5)*dx
-            mesh_dict["Y"] = (np.floor(np.arange(N)/settings["NX"]) + 0.5)*settings["DW"]*np.cos(theta)
+
+            dw = settings["W"] / settings["NW"]
+            theta = settings["DIP_W"] * np.pi / 180.0
+            mesh_dict["DIP_W"] = np.ones(N) * settings["DIP_W"]
+            mesh_dict["DW"] = np.ones(N) * dw
+            x = (np.arange(settings["NX"]) + 0.5) * dx
+            y = (np.arange(settings["NW"]) + 0.5) * dw * np.cos(theta)
+            X, Y = np.meshgrid(x, y, indexing="xy")
+            mesh_dict["X"] = X.ravel()
+            mesh_dict["Y"] = Y.ravel()
             mesh_dict["Z"] = settings["Z_CORNER"] + mesh_dict["Y"]*np.tan(theta)
 
         self.mesh_dict.update(mesh_dict)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -20,9 +20,12 @@ contains
 subroutine solve(pb)
 
   use output, only : write_output
-  use my_mpi, only : is_MPI_parallel, finalize_mpi
+  use my_mpi, only : is_MPI_parallel, finalize_mpi, synchronize_all
 
   type(problem_type), intent(inout)  :: pb
+
+  ! Synchronise all processes
+  if (is_MPI_parallel()) call synchronize_all()
 
   ! Before the first step, update field and write output (initial state)
   call update_field(pb)


### PR DESCRIPTION
- Initialisation of the MPI module was not complete, causing `NPROC=1` to remain unchanged
- Output modules caused MPI blocks (`MPI_ALLGATHER` was only called by MPI master proc)