### PR TITLE
Implementation restart model, fault labels and potency calculation

### DIFF
--- a/examples/notebooks/RSF_spring-block.ipynb
+++ b/examples/notebooks/RSF_spring-block.ipynb
@@ -505,7 +505,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('qdyn_test')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -5,7 +5,7 @@
 #EXEC_PATH = .
 #EXEC_PATH = $(HOME)/qdyn_svn/trunk/src/
 #EXEC_PATH = $(HOME)/bin/
-EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_2_4_0/
+EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_lastox/
 
 # 2. Comment/uncomment/add/modify the lines corresponding to your compiler:
 

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -5,7 +5,7 @@
 #EXEC_PATH = .
 #EXEC_PATH = $(HOME)/qdyn_svn/trunk/src/
 #EXEC_PATH = $(HOME)/bin/
-EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_lastox/
+EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_faultlabel/
 
 # 2. Comment/uncomment/add/modify the lines corresponding to your compiler:
 

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -5,7 +5,7 @@
 #EXEC_PATH = .
 #EXEC_PATH = $(HOME)/qdyn_svn/trunk/src/
 #EXEC_PATH = $(HOME)/bin/
-EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_2_4_0
+EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_2_4_0/
 
 # 2. Comment/uncomment/add/modify the lines corresponding to your compiler:
 

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -2,25 +2,26 @@
 
 # 1. Modify the path to the executable file only if you really need to place it elsewhere.
 #    If you change it, when you call qdyn.m you must set the input EXEC_PATH as set here
-EXEC_PATH = .
+#EXEC_PATH = .
 #EXEC_PATH = $(HOME)/qdyn_svn/trunk/src/
 #EXEC_PATH = $(HOME)/bin/
+EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_2_4_0
 
 # 2. Comment/uncomment/add/modify the lines corresponding to your compiler:
 
 # GNU, serial
 #Only MPI no openMP
-F90 = mpif90
-OPT = -O3 -Wall
+#F90 = mpif90
+#OPT = -O3 -Wall
 # For parallel runs with MPI+OpenMP:
 #F90 = mpif90
 #OPT = -O3 -Wall -fopenmp
 #OPT = -O2 -w
 #-- Intel Fortran --
-# F90 = ifort
+F90 = mpiifort
 # OPT = -O3 -ip -ipo
 # For parallel runs with OpenMP:
-#OPT = -O3 -ip -ipo -parallel -openmp -par-threshold:50
+OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50
 #-no-inline-factor
 #OPT = -O3 -pg -g
 #OPT = -O3
@@ -43,16 +44,16 @@ OPT = -O3 -Wall
 
 # 3. Set the compiler option that enables preprocessing in your compiler
 # ifort
-# PREPROC = -fpp
+PREPROC = -fpp
 # gfortran
-PREPROC = -cpp
+#PREPROC = -cpp
 #PG, KAUST server
 # CFLAGS = -B/usr/lib/x86_64-linux-gnu
 #CFLAGS = '' 
 
-test: F90 = mpif90
-	OPT = -O3 -Wall
-	PREPROC = -cpp
+test: F90 = mpiifort
+	OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50
+	PREPROC = -fpp
 
 #== END USER SETTINGS =============================================
 

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -11,17 +11,17 @@ EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_faultlabel/
 
 # GNU, serial
 #Only MPI no openMP
-#F90 = mpif90
+F90 = mpif90
 #OPT = -O3 -Wall
 # For parallel runs with MPI+OpenMP:
 #F90 = mpif90
-#OPT = -O3 -Wall -fopenmp
+OPT = -O3 -Wall -fopenmp
 #OPT = -O2 -w
 #-- Intel Fortran --
-F90 = mpiifort
+#F90 = mpiifort
 # OPT = -O3 -ip -ipo
 # For parallel runs with OpenMP:
-OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
+# OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
 #-no-inline-factor
 #OPT = -O3 -pg -g
 #OPT = -O3
@@ -44,16 +44,16 @@ OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
 
 # 3. Set the compiler option that enables preprocessing in your compiler
 # ifort
-PREPROC = -fpp
+# PREPROC = -fpp
 # gfortran
-#PREPROC = -cpp
+PREPROC = -cpp
 #PG, KAUST server
 # CFLAGS = -B/usr/lib/x86_64-linux-gnu
 #CFLAGS = '' 
 
-test: F90 = mpiifort
-	OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
-	PREPROC = -fpp
+test: F90 = mpif90
+	OPT = -O3 -Wall -fopenmp
+	PREPROC = -cpp
 
 #== END USER SETTINGS =============================================
 

--- a/qdyn/Makefile
+++ b/qdyn/Makefile
@@ -21,7 +21,7 @@ EXEC_PATH = /home/crodriguezpiceda/buildqdyn/qdyn_2_4_0/
 F90 = mpiifort
 # OPT = -O3 -ip -ipo
 # For parallel runs with OpenMP:
-OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50
+OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
 #-no-inline-factor
 #OPT = -O3 -pg -g
 #OPT = -O3
@@ -52,7 +52,7 @@ PREPROC = -fpp
 #CFLAGS = '' 
 
 test: F90 = mpiifort
-	OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50
+	OPT = -O3 -ip -ipo -parallel -qopenmp -par-threshold:50 -g -traceback
 	PREPROC = -fpp
 
 #== END USER SETTINGS =============================================

--- a/qdyn/constants.f90
+++ b/qdyn/constants.f90
@@ -54,6 +54,8 @@ integer :: SOLVER_TYPE = 0
 
 ! Input unit
 integer, parameter :: FID_IN = 15
+! Additional input unit (output_ox_last) if restarting model
+! integer, parameter :: FID_IN_LAST = 16
 
 ! Output units
 integer, parameter :: FID_SCREEN = 6

--- a/qdyn/constants.f90
+++ b/qdyn/constants.f90
@@ -68,7 +68,7 @@ integer, parameter :: FID_TIME = 121
 integer, parameter :: FID_STATIONS = 200
 integer, parameter :: FID_MW = 222
 integer, parameter :: FID_OX_DYN = 20000
-integer, parameter :: FID_FPTCY = 40000
+integer, parameter :: FID_FAULT = 40000
 
 ! Output names
 character(*), parameter :: FILE_OX = "output_ox"
@@ -80,6 +80,6 @@ character(*), parameter :: FILE_OT = "output_ot_"
 character(*), parameter :: FILE_IASP = "output_iasp"
 character(*), parameter :: FILE_VMAX = "output_vmax"
 character(*), parameter :: FILE_SCREEN = "log"
-character(*), parameter :: FILE_FPTCY = "output_fault_ptcy"
+character(*), parameter :: FILE_FAULT = "output_fault"
 
 end module constants

--- a/qdyn/constants.f90
+++ b/qdyn/constants.f90
@@ -78,5 +78,6 @@ character(*), parameter :: FILE_OX_DYN_MAX = "output_dyn_max_"
 character(*), parameter :: FILE_OT = "output_ot_"
 character(*), parameter :: FILE_IASP = "output_iasp"
 character(*), parameter :: FILE_VMAX = "output_vmax"
+character(*), parameter :: FILE_SCREEN = "log"
 
 end module constants

--- a/qdyn/constants.f90
+++ b/qdyn/constants.f90
@@ -59,6 +59,7 @@ integer, parameter :: FID_IN = 15
 integer, parameter :: FID_SCREEN = 6
 integer, parameter :: FID_OT = 18
 integer, parameter :: FID_OX = 19
+integer, parameter :: FID_OX_LAST = 30000
 integer, parameter :: FID_VMAX = 22
 integer, parameter :: FID_IASP = 23
 integer, parameter :: FID_QSB_PRE = 100
@@ -70,6 +71,7 @@ integer, parameter :: FID_OX_DYN = 20000
 
 ! Output names
 character(*), parameter :: FILE_OX = "output_ox"
+character(*), parameter :: FILE_OX_LAST = "output_ox_last"
 character(*), parameter :: FILE_OX_DYN_PRE = "output_dyn_pre_"
 character(*), parameter :: FILE_OX_DYN_POST = "output_dyn_post_"
 character(*), parameter :: FILE_OX_DYN_MAX = "output_dyn_max_"

--- a/qdyn/constants.f90
+++ b/qdyn/constants.f90
@@ -68,6 +68,7 @@ integer, parameter :: FID_TIME = 121
 integer, parameter :: FID_STATIONS = 200
 integer, parameter :: FID_MW = 222
 integer, parameter :: FID_OX_DYN = 20000
+integer, parameter :: FID_FPTCY = 40000
 
 ! Output names
 character(*), parameter :: FILE_OX = "output_ox"
@@ -79,5 +80,6 @@ character(*), parameter :: FILE_OT = "output_ot_"
 character(*), parameter :: FILE_IASP = "output_iasp"
 character(*), parameter :: FILE_VMAX = "output_vmax"
 character(*), parameter :: FILE_SCREEN = "log"
+character(*), parameter :: FILE_FPTCY = "output_fault_ptcy"
 
 end module constants

--- a/qdyn/fault_stress.f90
+++ b/qdyn/fault_stress.f90
@@ -317,7 +317,7 @@ subroutine init_kernel_3D_fft(k,lambda,mu,m,sigma_coupling)
       x_obs = m%x(jj)
       y_obs = m%y(jj)
       z_obs = m%z(jj)
-      dip_obs = m%dip(jj)
+      dip_obs = m%dip(jj) 
       do i=-m%nx+1,m%nx
         ! MvdE: the FFT will be applied along the x-coordinate, and so the x-coordinate
         ! of the observer should be as x = 0. The relative x-coordinate for the i-th

--- a/qdyn/fault_stress.f90
+++ b/qdyn/fault_stress.f90
@@ -369,6 +369,12 @@ subroutine init_kernel_3D_fft(k,lambda,mu,m,sigma_coupling)
   !    call save_array(m%xglob,m%yglob,m%zglob,m%zglob,my_mpi_rank(),'glo',k%nwGlobal,k%nx)
   ! endif
 
+! CRP: testing normal stress coupling
+  if (sigma_coupling) then
+    call log_screen("sigma_coupling=1") 
+  else
+    call log_screen("sigma_coupling=0")
+  endif
 
 end subroutine init_kernel_3D_fft
 

--- a/qdyn/initialize.f90
+++ b/qdyn/initialize.f90
@@ -11,7 +11,7 @@ contains
 subroutine init_all(pb)
 
   use problem_class
-  use mesh, only : init_mesh, mesh_get_size
+  use mesh, only : init_mesh, mesh_get_size,read_mesh_nodes
   use constants, only : PI, SOLVER_TYPE
   use my_mpi, only: is_MPI_master
   use logger, only : log_screen

--- a/qdyn/initialize.f90
+++ b/qdyn/initialize.f90
@@ -106,7 +106,7 @@ subroutine init_all(pb)
   endif
 
   call init_kernel( pb%lam, pb%smu, pb%mesh, pb%kernel, pb%D, pb%H, &
-                    pb%i_sigma_cpl, pb%finite, pb%test_mode)
+                    pb%features%stress_coupling, pb%finite, pb%test_mode)
 
   call initialize_output(pb)
 

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -42,7 +42,7 @@ subroutine read_main(pb)
   ! Read restart variable 
   read(FID_IN, *) pb%restart
   read(FID_IN, *) pb%restart_time
-  read(FID_IN, *) pb%restart_slip
+  !read(FID_IN, *) pb%restart_slip
 
   ! Read number of faults
   read(FID_IN, *) pb%nfault
@@ -267,5 +267,52 @@ subroutine read_main(pb)
 
 end subroutine read_main
 
+! subroutine read_lastox(pb)
+!   ! CRP: <RESTART>
+!   ! Read slip from last snapshot file output_last_ox. 
+!   ! This value will be used to compute the slip when restarting a model from
+!   ! a previous simulation
+
+!   use problem_class
+!   use logger, only : log_screen
+!   use constants, only : FID_IN_LAST, FID_SCREEN
+
+!   integer :: i, nn
+!   character :: header
+!   ! These are unused values
+!   double precision :: t, x, y, z,  v, theta, tau, tau_dot, sigma
+
+
+!   type(problem_type), intent(inout) :: pb
+
+!   if(pb%restart==1) then
+!     call log_screen("Start reading last snapshot...")
+
+!     ! open last snapshot
+!     open(unit=FID_IN_LAST, file='output_ox_last', action='read')
+    
+!     ! define number of mesh nodes
+!     nn = pb%mesh%nn
+!     write(FID_SCREEN, *) 'mesh elements = ', nn
+    
+!     ! read header
+!     read(FID_IN_LAST, *) header
+    
+!     ! allocate memory for the restart slip
+!     allocate(pb%restart_slip(nn))
+
+!     do i=1,nn
+!       ! read column with slip values. The remaining columns are unused.
+!       read(FID_IN_LAST, *) t, x, y, z,  v, theta, tau, tau_dot, pb%restart_slip(i), sigma
+!     enddo
+
+!     ! debugging: print restart_slip
+!     write(FID_SCREEN, *) 'restart_slip = ', pb%restart_slip
+
+!     close(FID_IN_LAST)
+!     call log_screen("Input last snapshot complete")  
+!   endif
+
+! end subroutine read_lastox
 
 end module input

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -37,6 +37,11 @@ subroutine read_main(pb)
   read(FID_IN, *) pb%itheta_law
   read(FID_IN, *) pb%i_rns_law
   read(FID_IN, *) pb%i_sigma_cpl
+
+  ! Read restart variable 
+  read(FID_IN, *) pb%restart
+
+
   ! SEISMIC: various simulation features can be turned on (1) or off (0)
   if (pb%i_rns_law == 3) then
     read(FID_IN, *) pb%cns_params%N_creep

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -25,6 +25,7 @@ subroutine read_main(pb)
 
   double precision, dimension(:), allocatable :: read_buf
   integer :: i, j, n, N_cols, N_creep
+  character :: myString
 
   call log_screen("Start reading input...")
 
@@ -246,12 +247,15 @@ subroutine read_main(pb)
   endif
   ! End reading TP model parameters
   ! </SEISMIC>
-
+  
+  ! CRP: Before: read_mesh_nodes was only called with 2D mesh
   if (pb%mesh%dim == 2) then
     call read_mesh_nodes(FID_IN, pb%mesh)
     ! call ot_read_stations(pb%ot)
   endif
 
+  ! CRP: test call read_mesh_nodes for all mesh types
+  !call read_mesh_nodes(FID_IN, pb%mesh)
   close(FID_IN)
   call log_screen("Input complete")
 

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -249,13 +249,15 @@ subroutine read_main(pb)
   ! </SEISMIC>
   
   ! CRP: Before: read_mesh_nodes was only called with 2D mesh
-  if (pb%mesh%dim == 2) then
-    call read_mesh_nodes(FID_IN, pb%mesh)
-    ! call ot_read_stations(pb%ot)
-  endif
+  ! if (pb%mesh%dim == 2) then
+  !   call read_mesh_nodes(FID_IN, pb%mesh)
+  !   ! call ot_read_stations(pb%ot)
+  ! endif
 
-  ! CRP: test call read_mesh_nodes for all mesh types
-  !call read_mesh_nodes(FID_IN, pb%mesh)
+  ! CRP: Instead, call read_mesh_nodes for all mesh types so the fault label can
+  ! be written in the outputs for all fault dimensionalities
+  call read_mesh_nodes(FID_IN, pb%mesh)
+
   close(FID_IN)
   call log_screen("Input complete")
 

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -42,6 +42,10 @@ subroutine read_main(pb)
   ! Read restart variable 
   read(FID_IN, *) pb%restart
   read(FID_IN, *) pb%restart_time
+  read(FID_IN, *) pb%restart_slip
+
+  ! Read number of faults
+  read(FID_IN, *) pb%nfault
 
   ! SEISMIC: various simulation features can be turned on (1) or off (0)
   if (pb%i_rns_law == 3) then

--- a/qdyn/input.f90
+++ b/qdyn/input.f90
@@ -40,7 +40,7 @@ subroutine read_main(pb)
 
   ! Read restart variable 
   read(FID_IN, *) pb%restart
-
+  read(FID_IN, *) pb%restart_time
 
   ! SEISMIC: various simulation features can be turned on (1) or off (0)
   if (pb%i_rns_law == 3) then

--- a/qdyn/main.f90
+++ b/qdyn/main.f90
@@ -40,6 +40,7 @@ program main
 
   call init_mpi()
   call read_main(pb)
+  !call read_lastox(pb)
   call init_all(pb)
   call solve(pb)
 

--- a/qdyn/mesh.f90
+++ b/qdyn/mesh.f90
@@ -90,6 +90,7 @@ subroutine read_mesh_nodes(iin,m)
 end subroutine read_mesh_nodes
 
 !=============================================================
+
 integer function mesh_get_size(m) result(n)
   type(mesh_type), intent(in) :: m
   n = m%nn
@@ -120,7 +121,7 @@ subroutine init_mesh_0D(m)
   type(mesh_type), intent(inout) :: m
 
   call log_screen("Spring-block System")
-  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn))
+  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn))
   allocate(m%dx(1), m%dw(1))
   m%nx = 1
   m%nw = 1
@@ -132,6 +133,7 @@ subroutine init_mesh_0D(m)
   m%y = 0d0
   m%z = 0d0
   m%fault_label = 1d0
+
 end subroutine init_mesh_0D
 
 !--------------------------------------------------------
@@ -148,7 +150,7 @@ subroutine init_mesh_1D(m)
   m%nw = 1
   m%dx = m%Lfault/m%nn
   m%dw = 1d0
-  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn))
+  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn))
   do i=1,m%nn
     m%x(i) = (i-m%nn*0.5d0-0.5d0)*m%dx(1)
     ! Assuming nn is even (usually a power of 2),
@@ -156,6 +158,7 @@ subroutine init_mesh_1D(m)
     ! are located at x=-dx/2 and x=dx/2, respectively
     m%y(i) = 0d0
     m%z(i) = 0d0
+    m%fault_label(i) = 0d0
   enddo
 
   m%xglob => m%x
@@ -163,7 +166,7 @@ subroutine init_mesh_1D(m)
   m%zglob => m%z
   m%nxglob = m%nx
   m%nwglob = m%nw
-
+  m%fault_label_glob => m%x
 end subroutine init_mesh_1D
 
 !--------------------------------------------------------

--- a/qdyn/mesh.f90
+++ b/qdyn/mesh.f90
@@ -13,6 +13,7 @@ module mesh
     ! Local mesh coordinates
     double precision, pointer :: x(:) => null(), y(:) => null(), z(:) => null()
     double precision, pointer :: fault_label(:) => null()
+    double precision, pointer :: restart_slip(:) => null()
     ! Local dip, and along-strike and along-dip size of grid cells (nx*nw count)
     ! TODO: grid sizes should be constant in order for FFT to work!
     double precision, pointer :: dip(:) => null(), dx(:) => null(), dw(:) => null()
@@ -20,6 +21,7 @@ module mesh
     double precision, pointer :: xglob(:) => null(), yglob(:) => null(), zglob(:) => null()
     double precision, pointer :: dipglob(:) => null(), dwglob(:) => null()
     double precision, pointer :: fault_label_glob(:) => null()
+    double precision, pointer :: restart_slip_glob(:) => null()
   end type mesh_type
 
   ! SEISMIC: discretisation of spectral domain for diffusion solver
@@ -82,9 +84,9 @@ subroutine read_mesh_nodes(iin,m)
 
   integer :: i
 
-  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%dip(m%nn), m%fault_label(m%nn))
+  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%dip(m%nn), m%fault_label(m%nn), m%restart_slip(m%nn))
   do i=1,m%nn
-    read(iin,*) m%x(i),m%y(i),m%z(i),m%dip(i), m%fault_label(i)
+    read(iin,*) m%x(i),m%y(i),m%z(i),m%dip(i), m%fault_label(i), m%restart_slip(i)
   enddo
 
 end subroutine read_mesh_nodes
@@ -121,7 +123,7 @@ subroutine init_mesh_0D(m)
   type(mesh_type), intent(inout) :: m
 
   call log_screen("Spring-block System")
-  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn))
+  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn), m%restart_slip(m%nn))
   allocate(m%dx(1), m%dw(1))
   m%nx = 1
   m%nw = 1
@@ -133,6 +135,7 @@ subroutine init_mesh_0D(m)
   m%y = 0d0
   m%z = 0d0
   m%fault_label = 1d0
+  m%restart_slip= 0d0
 
 end subroutine init_mesh_0D
 
@@ -150,7 +153,7 @@ subroutine init_mesh_1D(m)
   m%nw = 1
   m%dx = m%Lfault/m%nn
   m%dw = 1d0
-  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn))
+  allocate(m%x(m%nn), m%y(m%nn), m%z(m%nn), m%fault_label(m%nn), m%restart_slip(m%nn))
   do i=1,m%nn
     m%x(i) = (i-m%nn*0.5d0-0.5d0)*m%dx(1)
     ! Assuming nn is even (usually a power of 2),
@@ -158,7 +161,8 @@ subroutine init_mesh_1D(m)
     ! are located at x=-dx/2 and x=dx/2, respectively
     m%y(i) = 0d0
     m%z(i) = 0d0
-    m%fault_label(i) = 0d0
+    m%fault_label(i) = 1d0
+    m%restart_slip(i) = 0d0
   enddo
 
   m%xglob => m%x
@@ -166,7 +170,9 @@ subroutine init_mesh_1D(m)
   m%zglob => m%z
   m%nxglob = m%nx
   m%nwglob = m%nw
-  m%fault_label_glob => m%x
+  m%fault_label_glob => m%fault_label
+  m%restart_slip_glob => m%restart_slip
+
 end subroutine init_mesh_1D
 
 !--------------------------------------------------------
@@ -204,6 +210,7 @@ subroutine init_mesh_2D(m)
     m%dwglob => m%dw
     m%nwglob = m%nw
     m%fault_label_glob => m%fault_label
+    m%restart_slip_glob => m%restart_slip
 
   ! Parallel mode: gather mesh node locations for computing the kernel
   else
@@ -242,7 +249,7 @@ subroutine init_mesh_2D(m)
 
    ! Allocate global mesh for computing the kernel and for outputs
     allocate(m%xglob(nnGlobal),m%yglob(nnGlobal),&
-             m%zglob(nnGlobal),m%dwglob(nwGlobal),m%dipglob(nnGlobal), m%fault_label_glob(nnGlobal))
+             m%zglob(nnGlobal),m%dwglob(nwGlobal),m%dipglob(nnGlobal), m%fault_label_glob(nnGlobal), m%restart_slip_glob(nnGlobal))
 
     ! Gather mesh nodes
     call gather_allvdouble(m%x,   nnLocal, m%xglob,   nnLocal_perproc, nnoffset_glob_perproc, nnGlobal)
@@ -251,6 +258,7 @@ subroutine init_mesh_2D(m)
     call gather_allvdouble(m%dip, nnLocal, m%dipglob, nnLocal_perproc, nnoffset_glob_perproc, nnGlobal)
     call gather_allvdouble(m%dw,  nwLocal, m%dwglob,  nwLocal_perproc, nwoffset_glob_perproc, nwGlobal)
     call gather_allvdouble(m%fault_label,  nnLocal, m%fault_label_glob,  nnLocal_perproc, nnoffset_glob_perproc, nnGlobal)
+    call gather_allvdouble(m%restart_slip,  nnLocal, m%restart_slip_glob,  nnLocal_perproc, nnoffset_glob_perproc, nnGlobal)
 
 endif
 

--- a/qdyn/okada.f90
+++ b/qdyn/okada.f90
@@ -92,8 +92,8 @@ subroutine compute_kernel(LAM,MU,SX,SY,SZ,S_DIP,L,W,OX,OY,OZ,O_DIP,IRET,tau,sigm
       Ustrike = 0d0
       Udip = -1d0
       n_dir(1) = 0d0
-      n_dir(2) = -cos(O_DIP/180d0*PI) ! WARNING (JPA): remove minus sign (footwall moves up)
-      n_dir(3) = -sin(O_DIP/180d0*PI) ! WARNING (JPA): remove minus sign
+      n_dir(2) = cos(O_DIP/180d0*PI) ! no minus sign (footwall moves up)
+      n_dir(3) = sin(O_DIP/180d0*PI) ! no minus sign
     case default
       stop 'FATAL ERROR in okada.compute_kernel : mode should be +/- 1 (strike-slip) or 2 (thrust)'
   end select

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -439,7 +439,7 @@ subroutine ot_init(pb)
   ! Overwrite IASP in pb%ot
   pb%ot%iasp = iasp_list
 
-  ! Open files, write headers
+  ! Open files, write headers (if not restarting the simulation from a previous simulation)
   if (is_MPI_master()) then
 
     ! Time series output: loop over all OT locations
@@ -448,31 +448,37 @@ subroutine ot_init(pb)
       ! Write headers
       write(tmp, "(a, i0)") FILE_OT, pb%ot%iot(i) - 1
       iot_name = trim(tmp)
-      open(id, file=iot_name, status="replace")
-      write(id, "(a)") "# macroscopic values:"
-      write(id, "(a)") "# 1=t, 2=pot, 3=pot_rate"
-      write(id, "(a)") "# values at selected point:"
-      write(id, "(a)") "# 4=V, 5=theta, 6=tau, 7=dtau_dt, 8=slip, 9=sigma"
-      if (pb%features%tp == 1) then
-        write(id, "(a)") "# 10=P, 11=T"
-      endif
+      if (pb%restart==0) then
+        open(id, file=iot_name, status="replace")
+        write(id, "(a)") "# macroscopic values:"
+        write(id, "(a)") "# 1=t, 2=pot, 3=pot_rate"
+        write(id, "(a)") "# values at selected point:"
+        write(id, "(a)") "# 4=V, 5=theta, 6=tau, 7=dtau_dt, 8=slip, 9=sigma"
+        if (pb%features%tp == 1) then
+          write(id, "(a)") "# 10=P, 11=T"
+        endif
+      endif 
       close(id)
     enddo
 
     ! Vmax output
-    open(FID_VMAX, file=FILE_VMAX, status="replace")
-    write(FID_VMAX, "(a)") "# values at max(V) location:"
-    write(FID_VMAX, "(a)") "# 1=t, 2=ivmax, 3=v, 4=theta, 5=tau, 6=dtau_dt, 7=slip, 8=sigma"
-    if (pb%features%tp == 1) then
-      write(FID_VMAX, "(a)") "# 9=P, 10=T"
+    if (pb%restart==0) then
+      open(FID_VMAX, file=FILE_VMAX, status="replace")
+      write(FID_VMAX, "(a)") "# values at max(V) location:"
+      write(FID_VMAX, "(a)") "# 1=t, 2=ivmax, 3=v, 4=theta, 5=tau, 6=dtau_dt, 7=slip, 8=sigma"
+      if (pb%features%tp == 1) then
+        write(FID_VMAX, "(a)") "# 9=P, 10=T"
+      endif
     endif
     close(FID_VMAX)
 
     ! IASP output
-    open(FID_IASP, file=FILE_IASP, status="replace")
-    write(FID_IASP, "(a)") "# Seismicity record:"
-    write(FID_IASP, "(a)") "# 1=i, 2=t, 3=v"
-    close(FID_IASP)
+    if (pb%restart==0) then
+      open(FID_IASP, file=FILE_IASP, status="replace")
+      write(FID_IASP, "(a)") "# Seismicity record:"
+      write(FID_IASP, "(a)") "# 1=i, 2=t, 3=v"
+      close(FID_IASP)
+    endif
 
   endif
 
@@ -531,11 +537,13 @@ subroutine ox_init(pb)
 
   ! Create ox file (if not split over multiple files)
   if (pb%ox%i_ox_seq == 0) then
-    open(FID_OX, file=FILE_OX, status="replace")
-    close(FID_OX)
+    if (pb%restart==0) then
+      open(FID_OX, file=FILE_OX, status="replace")
+      close(FID_OX)
+    endif
   endif
 
-  ! Create ox file for last snapshot 
+  ! CRP: Create ox file for last snapshot 
   if (pb%ox%i_ox_seq == 0) then
     open(FID_OX_LAST, file=FILE_OX_LAST, status="replace")
     close(FID_OX_LAST)

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -487,7 +487,7 @@ subroutine ot_init(pb)
     if (pb%restart==0) then
       open(FID_VMAX, file=FILE_VMAX, status="replace")
       write(FID_VMAX, "(a)") "# values at max(V) location:"
-      write(FID_VMAX, "(a)") "# 1=t, 2=ivmax, 3=v, 4=theta, 5=tau, 6=dtau_dt, 7=slip, 8=sigma"
+      write(FID_VMAX, "(a)") "# 1=t, 2=ivmax, 3=v, 4=theta, 5=tau, 6=dtau_dt, 7=slip, 8=sigma 9=fault_label"
       if (pb%features%tp == 1) then
         write(FID_VMAX, "(a)") "# 9=P, 10=T"
       endif
@@ -498,7 +498,7 @@ subroutine ot_init(pb)
     if (pb%restart==0) then
       open(FID_IASP, file=FILE_IASP, status="replace")
       write(FID_IASP, "(a)") "# Seismicity record:"
-      write(FID_IASP, "(a)") "# 1=i, 2=t, 3=v"
+      write(FID_IASP, "(a)") "# 1=i, 2=t, 3=v, 4=fault_label"
       close(FID_IASP)
     endif
 
@@ -514,6 +514,7 @@ subroutine ox_init(pb)
   use problem_class
   use constants, only: FID_OX, FILE_OX, FID_OX_LAST, FILE_OX_LAST
   use my_mpi, only : is_MPI_parallel, is_mpi_master
+  use logger, only:log_screen
 
   type (problem_type), intent(inout) :: pb
 
@@ -692,7 +693,7 @@ subroutine ot_write(pb)
       if ((pb%ot%v_pre(n) >= pb%ot%v_th) .and. &
           (pb%v_glob(n) < pb%ot%v_pre(n)) .and. &
           (pb%ot%v_pre(n) >= pb%ot%v_pre2(n))) then
-          write(FID_IASP, "(i10, 2e24.16)") n, pb%time, pb%ot%v_pre(n)
+          write(FID_IASP, "(i10, 2e24.16)") n, pb%time, pb%ot%v_pre(n), pb%mesh%fault_label(n)
       endif
     enddo
     close(FID_IASP)

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -37,7 +37,8 @@ subroutine initialize_output(pb)
 
   ! Overwrite number of objects to output
   pb%nobj = nobj
-
+  
+    
   ! Allocate containers
   allocate(pb%objects_glob(nobj))
   allocate(pb%objects_loc(nobj))
@@ -71,6 +72,11 @@ subroutine initialize_output(pb)
   endif
 
   ! Assign global quantities (for output)
+
+  ! overwrite time if restart with last simulation
+  if(pb%restart==1) then
+    pb%time=pb%time+pb%restart_time
+  endif
 
   ! [double scalar] time, potency, potency rate
   pb%objects_glob(1)%s => pb%time

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -443,40 +443,44 @@ subroutine ot_init(pb)
     iasp_buf = pb%ot%iasp
   endif
 
-  ! Get the number of OT output indices
-  niot = sum(iot_buf)
-  ! Allocate space for a list of iot indices
-  allocate(iot_list(niot))
-  iot_count = 0
-  ! Loop over all potential OT locations
-  do i=1,nnGlobal
-    ! If location is OT location
-    if (iot_buf(i) == 1) then
-      iot_count = iot_count + 1
-      iot_list(iot_count) = i
-    endif
-  enddo
+  if (is_MPI_master()) then
 
-  ! Overwrite IOT in pb%ot
-  pb%ot%iot = iot_list
+    ! Get the number of OT output indices
+    niot = sum(iot_buf)
+    ! Allocate space for a list of iot indices
+    allocate(iot_list(niot))
+    iot_count = 0
+    ! Loop over all potential OT locations
+    do i=1,nnGlobal
+      ! If location is OT location
+      if (iot_buf(i) == 1) then
+        iot_count = iot_count + 1
+        iot_list(iot_count) = i
+      endif
+    enddo
 
-  ! Get the number of IASP output indices
-  niasp = sum(iasp_buf)
-  ! Allocate space for a list of iasp indices
-  allocate(iasp_list(niasp))
-  iasp_count = 0
-  ! Loop over all potential OT locations
-  do i=1,nnGlobal
-    ! If location is OT location
-    if (iasp_buf(i) == 1) then
-      iasp_count = iasp_count + 1
-      iasp_list(iasp_count) = i
-    endif
-  enddo
+    ! Overwrite IOT in pb%ot
+    pb%ot%iot = iot_list
 
-  ! Overwrite IASP in pb%ot
-  pb%ot%iasp = iasp_list
+    ! Get the number of IASP output indices
+    niasp = sum(iasp_buf)
+    ! Allocate space for a list of iasp indices
+    allocate(iasp_list(niasp))
+    iasp_count = 0
+    ! Loop over all potential OT locations
+    do i=1,nnGlobal
+      ! If location is OT location
+      if (iasp_buf(i) == 1) then
+        iasp_count = iasp_count + 1
+        iasp_list(iasp_count) = i
+      endif
+    enddo
 
+    ! Overwrite IASP in pb%ot
+    pb%ot%iasp = iasp_list
+
+  endif
+  
   ! Open files, write headers (if not restarting the simulation with time of last simulation)
   if (is_MPI_master()) then
 

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -58,6 +58,7 @@ subroutine initialize_output(pb)
     pb%mesh%xglob => pb%mesh%x
     pb%mesh%yglob => pb%mesh%y
     pb%mesh%zglob => pb%mesh%z
+    pb%mesh%fault_label_glob => pb%mesh%fault_label
     ! Mechanical quantities
     pb%v_glob => pb%v
     pb%theta_glob => pb%theta
@@ -101,6 +102,8 @@ subroutine initialize_output(pb)
   pb%objects_glob(7)%v => pb%dtau_dt_glob
   pb%objects_glob(8)%v => pb%slip_glob
   pb%objects_glob(9)%v => pb%sigma_glob
+  ! [double vector] fault label
+  pb%objects_glob(10)%v => pb%mesh%fault_label_glob
 
   ! If thermal pressurisation is requested, add P and T
   if (pb%features%tp == 1) then
@@ -123,6 +126,8 @@ subroutine initialize_output(pb)
   pb%objects_loc(7)%v => pb%dtau_dt
   pb%objects_loc(8)%v => pb%slip
   pb%objects_loc(9)%v => pb%sigma
+  ! [double vector] fault label
+  pb%objects_loc(10)%v => pb%mesh%fault_label_loc
 
   ! If thermal pressurisation is requested, add P and T
   if (pb%features%tp == 1) then
@@ -331,6 +336,7 @@ end subroutine time_write
 
 
 !=====================================================================
+! CRP: Is this subrutine used somewhere?
 subroutine ot_read_stations(ot)
 
   use problem_class, only : ot_type
@@ -881,7 +887,7 @@ subroutine ox_write(pb)
             write(unit, '(3e15.7,4e28.20)') &
               pb%mesh%xglob(n), pb%mesh%yglob(n), pb%mesh%zglob(n), &
               pb%t_rup_glob(n), pb%tau_max_glob(n), pb%t_vmax_glob(n), &
-              pb%v_max_glob(n)
+              pb%v_max_glob(n) pb%mesh%fault_label(n)
           enddo
         enddo
         ! Close output unit

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -516,15 +516,15 @@ subroutine ot_init(pb)
     if (pb%restart==0) then
       open(FID_FAULT, file=FILE_FAULT, status="replace")
       write(FID_FAULT, "(a)") "# fault values:"
-      write(FID_FAULT, "(a)", advance="no") "# 1=t "
+      write(FID_FAULT, "(a)", advance="no") "# t "
       do i=1, pb%nfault
-        write(FID_FAULT, "(a, i0)", advance="no") " 2=pot_", i
+        write(FID_FAULT, "(a, i0)", advance="no") " pot_", i
       enddo
       do i=1, pb%nfault
-        write(FID_FAULT, "(a, i0)", advance="no") " 3=pot_rate_", i
+        write(FID_FAULT, "(a, i0)", advance="no") " pot_rate_", i
       enddo
       do i=1, pb%nfault
-        write(FID_FAULT, "(a, i0)", advance="no") " 4=slip_dt_", i
+        write(FID_FAULT, "(a, i0)", advance="no") " slip_dt_", i
       enddo
 
       close(FID_FAULT)
@@ -1059,11 +1059,6 @@ subroutine write_fault_lines(unit, fmt, fmt_fault, objects, pot_fault, pot_rate_
 
   ! Write time
   write(unit, fmt(1), advance="no") objects(1)%s
-  ! ! Write pot_fault and pot_rate_fault (do not advance to next line)
-  ! write(unit, fmt_fault(1), advance="no") pot_fault
-  ! write(unit, fmt_fault(2), advance="no") pot_rate_fault
-  ! ! Write slip_dt fault (advance to next line)
-  ! write(unit, fmt_fault(3)) slip_dt_fault
 
   do i=1, pb%nfault
     ! Write pot_fault and pot_rate_fault (do not advance to next line)

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -21,9 +21,15 @@ subroutine initialize_output(pb)
 
   ! The spirit of the output module is as follows:
   ! First, a container of pointers is created that is shared by all the output
-  ! modules (time series, snapshots, etc). Then, for each output type, the
+  ! submodules (time series, snapshots, etc). Then, for each output type, the
   ! indices pointing to the appropriate quantities are stored in a list. When
-  ! a particular output is requested, the AAAAARRRRGHHH...
+  ! a particular output is requested, the corresponding submodule calls for the
+  ! appropiate quantity stored in the list. The time value that is output in
+  ! each time-step depends on the flag "restart" that was set in the input file.
+  ! If the simulation starts at 0s ("restart" = 0), then all the output files
+  ! are created from scratch/rewritten. Otherwise, if the simulation is intended
+  ! to start from the last time-step of a previous simulation ("restart"=1), then
+  ! the output is appended to the existing output files from this previous simulation.   
 
   ! Number of objects in containers
   ! Base number
@@ -73,7 +79,7 @@ subroutine initialize_output(pb)
 
   ! Assign global quantities (for output)
 
-  ! overwrite time if restart with last simulation
+  ! overwrite time if restart with time of last simulation
   if(pb%restart==1) then
     pb%time=pb%time+pb%restart_time
   endif
@@ -179,7 +185,7 @@ subroutine screen_init_log(pb)
   if (pb%restart==0) then
     open(FID_SCREEN, file=FILE_SCREEN)
   elseif (pb%restart==1) then
-  ! TO DO: if restart, append in existing log file
+  ! If restart with time of last simulation, append in existing log file
     open(FID_SCREEN, file=FILE_SCREEN, status = "old", position="append")
   endif
 
@@ -445,7 +451,7 @@ subroutine ot_init(pb)
   ! Overwrite IASP in pb%ot
   pb%ot%iasp = iasp_list
 
-  ! Open files, write headers (if not restarting the simulation from a previous simulation)
+  ! Open files, write headers (if not restarting the simulation with time of last simulation)
   if (is_MPI_master()) then
 
     ! Time series output: loop over all OT locations
@@ -549,7 +555,7 @@ subroutine ox_init(pb)
     endif
   endif
 
-  ! CRP: Create ox file for last snapshot 
+  ! Create ox file for last snapshot 
   if (pb%ox%i_ox_seq == 0) then
     open(FID_OX_LAST, file=FILE_OX_LAST, status="replace")
     close(FID_OX_LAST)

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -514,7 +514,6 @@ subroutine ox_init(pb)
   use problem_class
   use constants, only: FID_OX, FILE_OX, FID_OX_LAST, FILE_OX_LAST
   use my_mpi, only : is_MPI_parallel, is_mpi_master
-  use logger, only:log_screen
 
   type (problem_type), intent(inout) :: pb
 
@@ -892,7 +891,7 @@ subroutine ox_write(pb)
             write(unit, '(3e15.7,4e28.20)') &
               pb%mesh%xglob(n), pb%mesh%yglob(n), pb%mesh%zglob(n), &
               pb%t_rup_glob(n), pb%tau_max_glob(n), pb%t_vmax_glob(n), &
-              pb%v_max_glob(n), pb%mesh%fault_label(n)
+              pb%v_max_glob(n), pb%mesh%fault_label_glob(n)
           enddo
         enddo
         ! Close output unit

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -1275,7 +1275,6 @@ subroutine calc_potency_fault(pb)
   ! potency rate = velocity * area 
   pot_dt = slip_dt * area
   pot_rate_dt = pb%v * area
-  !pot_rate_dt = pot_dt/pb%dt_did
 
   ! Step 4: sum potency, potency rate and delta slip per fault
   do n=1, pb%mesh%nn
@@ -1286,21 +1285,6 @@ subroutine calc_potency_fault(pb)
     pot_rate_fault(lbl) = pot_rate_fault(lbl) + pot_rate_dt(n)
     slip_dt_fault(lbl) = slip_dt_fault(lbl) + slip_dt(n)
   end do
-
-  ! reduce for MPI
-  ! do n=1, pb%nfault
-  !   if (is_MPI_parallel()) then
-  !     buf(1)=pot_fault(n)
-  !     call sum_allreduce(buf(1), 1)
-  !     pot_fault(n) = buf(1)
-  !     if (is_mpi_master()) then
-  !       write(FID_SCREEN, *) 'slip_dt_fault 1 = ', slip_dt_fault(1)
-  !       write(FID_SCREEN, *) 'pot_fault 1 = ', pot_fault(1)
-  !       write(FID_SCREEN, *) 'pot_rate_fault 1 = ', pot_rate_fault(1)
-  !     endif
-  !   else
-  !   endif
-  ! enddo
 
   ! reduce potency, potency rate and delta slip for MPI
   do n=1, pb%nfault
@@ -1316,17 +1300,18 @@ subroutine calc_potency_fault(pb)
       buf_slip_dt(1)=slip_dt_fault(n)
       call sum_allreduce(buf_slip_dt(1), 1)
       slip_dt_fault(n) = buf_slip_dt(1)
+
     endif
   enddo
 
   ! debugging: print values of slip_dt, pot and pot_rate
-  if (is_mpi_master()) then
-    write(FID_SCREEN, *) 'slip_dt_fault 1 = ', slip_dt_fault(1)
-    write(FID_SCREEN, *) 'pot_fault 1 = ', pot_fault(1)
-    write(FID_SCREEN, *) 'pot_rate_fault 1 = ', pot_rate_fault(1)
-  endif
+  ! if (is_mpi_master()) then
+  !   write(FID_SCREEN, *) 'slip_dt_fault 1 = ', slip_dt_fault(1)
+  !   write(FID_SCREEN, *) 'pot_fault 1 = ', pot_fault(1)
+  !   write(FID_SCREEN, *) 'pot_rate_fault 1 = ', pot_rate_fault(1)
+  ! endif
 
-  ! assign variables to problem class variables
+  ! assign quantities to problem class variables
   pb%pot_fault = pot_fault
   pb%pot_rate_fault = pot_rate_fault
   pb%slip_dt_fault = slip_dt_fault

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -127,7 +127,7 @@ subroutine initialize_output(pb)
   pb%objects_loc(8)%v => pb%slip
   pb%objects_loc(9)%v => pb%sigma
   ! [double vector] fault label
-  pb%objects_loc(10)%v => pb%mesh%fault_label_loc
+  pb%objects_loc(10)%v => pb%mesh%fault_label
 
   ! If thermal pressurisation is requested, add P and T
   if (pb%features%tp == 1) then
@@ -384,9 +384,9 @@ subroutine ot_init(pb)
   pb%ot%v_pre2 = 0.d0
 
   ! Number of ot output quantities
-  pb%ot%not = 9
+  pb%ot%not = 10
   ! Number of ot_vmax output quantities
-  pb%ot%not_vmax = 8
+  pb%ot%not_vmax = 9
   ! If thermal pressurisation is requested, add 2 more
   if (pb%features%tp == 1) then
     pb%ot%not = pb%ot%not + 2
@@ -400,6 +400,8 @@ subroutine ot_init(pb)
   pb%ot%fmt = "(e15.7)"
   ! Time needs higher precision
   pb%ot%fmt(1) = "(e24.14)"
+  ! TO DO: right format for fault label
+  !pb%ot%fmt(10) = "(e15.0)"
 
   ! Default vmax output format
   pb%ot%fmt_vmax = "(e15.7)"
@@ -407,6 +409,8 @@ subroutine ot_init(pb)
   pb%ot%fmt_vmax(1) = "(e24.14)"
   ! vmax location is an integer
   pb%ot%fmt_vmax(2) = "(i15)"
+  ! TO DO: right format for fault label in vmax
+  !pb%ot%fmt_vmax(9) = "(e15.0)"
 
   ! If parallel:
   if (is_MPI_parallel()) then
@@ -471,7 +475,7 @@ subroutine ot_init(pb)
         write(id, "(a)") "# macroscopic values:"
         write(id, "(a)") "# 1=t, 2=pot, 3=pot_rate"
         write(id, "(a)") "# values at selected point:"
-        write(id, "(a)") "# 4=V, 5=theta, 6=tau, 7=dtau_dt, 8=slip, 9=sigma"
+        write(id, "(a)") "# 4=V, 5=theta, 6=tau, 7=dtau_dt, 8=slip, 9=sigma, 10=fault_label"
         if (pb%features%tp == 1) then
           write(id, "(a)") "# 10=P, 11=T"
         endif
@@ -568,9 +572,9 @@ subroutine ox_init(pb)
   endif
 
   ! Define headers
-  pb%ox%header = '# t x y z v theta tau tau_dot slip sigma'
+  pb%ox%header = '# t x y z v theta tau tau_dot slip sigma fault_label'
   if (pb%features%tp == 1) then
-    pb%ox%header = '# t x y z v theta tau tau_dot slip sigma P T'
+    pb%ox%header = '# t x y z v theta tau tau_dot slip sigma fault_label P T'
   endif
 
   ! If ox_dyn is requested
@@ -887,7 +891,7 @@ subroutine ox_write(pb)
             write(unit, '(3e15.7,4e28.20)') &
               pb%mesh%xglob(n), pb%mesh%yglob(n), pb%mesh%zglob(n), &
               pb%t_rup_glob(n), pb%tau_max_glob(n), pb%t_vmax_glob(n), &
-              pb%v_max_glob(n) pb%mesh%fault_label(n)
+              pb%v_max_glob(n), pb%mesh%fault_label(n)
           enddo
         enddo
         ! Close output unit

--- a/qdyn/output.f90
+++ b/qdyn/output.f90
@@ -766,7 +766,8 @@ subroutine ot_write(pb)
 
     ! Write fault data (potency, potency rate and slip_dt)
     open(FID_FAULT, file=FILE_FAULT, status="old", position="append")
-    call write_fault_lines(FID_FAULT, pb%ot%fmt, pb%ot%fmt_fault, pb%objects_glob, pb%pot_fault, pb%pot_rate_fault, pb%slip_dt_fault, pb)
+    call write_fault_lines(FID_FAULT, pb%ot%fmt, pb%ot%fmt_fault, pb%objects_glob, &
+    pb%pot_fault, pb%pot_rate_fault, pb%slip_dt_fault, pb)
     close(FID_FAULT)
   endif
 
@@ -1251,7 +1252,7 @@ subroutine calc_potency_fault(pb)
   use constants, only: FID_SCREEN
 
   type(problem_type), intent(inout) :: pb
-  double precision, dimension(pb%mesh%nn) :: area, slip_dt, pot_dt, pot_rate_dt, index_label_min, index_label_max
+  double precision, dimension(pb%mesh%nn) :: area, slip_dt, pot_dt, pot_rate_dt
   double precision, dimension(pb%nfault) :: pot_fault, pot_rate_fault, slip_dt_fault
   double precision, dimension(1) :: buf_pot, buf_pot_rate, buf_slip_dt
   integer :: iw, ix, n, lbl
@@ -1283,7 +1284,7 @@ subroutine calc_potency_fault(pb)
   ! Step 4: sum potency, potency rate and delta slip per fault
   do n=1, pb%mesh%nn
     ! Check fault label
-    lbl = pb%mesh%fault_label(n)
+    lbl = INT(pb%mesh%fault_label(n))
     ! sum potency, potency rate and delta slip
     pot_fault(lbl) = pot_fault(lbl) + pot_dt(n)
     pot_rate_fault(lbl) = pot_rate_fault(lbl) + pot_rate_dt(n)

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -168,7 +168,8 @@ module problem_class
 
     ! Restart
     integer :: restart
-    double precision :: restart_time, restart_slip
+    double precision :: restart_time
+    !double precision, pointer :: restart_slip(:) => null()
 
     ! Number of fault labels
     integer :: nfault

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -23,9 +23,9 @@ module problem_class
   type ot_type
     double precision :: v_th
     double precision, dimension(:), allocatable :: xsta, ysta, zsta, v_pre, v_pre2
-    integer :: ic=-1, ntout=0, not=-1, not_vmax=-1
+    integer :: ic=-1, ntout=0, not=-1, not_vmax=-1, not_fault = -1
     integer, dimension(:), allocatable :: iasp, iot
-    character(len=16), dimension(:), allocatable :: fmt, fmt_vmax
+    character(len=16), dimension(:), allocatable :: fmt, fmt_vmax, fmt_fault
     type(optr), dimension(:), allocatable :: objects_ot, objects_vmax
   end type ot_type
 
@@ -121,11 +121,8 @@ module problem_class
                                   v_max(:) => null(), t_vmax(:) => null()
     ! Potency variables
     double precision, pointer :: pot => null(), pot_rate => null()
-  
-    ! Fault label variables
-    !double precision, dimension(:), allocatable :: unique_labels, freq_labels, cumsum_freq_labels
-    ! Fault potency variables
-    double precision, dimension(:), allocatable :: pot_fault, pot_rate_fault
+    ! Fault variables
+    double precision, dimension(:), allocatable :: pot_fault, pot_rate_fault, slip_dt_fault
    ! Boundary conditions
     integer :: i_sigma_cpl=0, finite=0
    ! Friction properties

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -165,7 +165,8 @@ module problem_class
 
     ! Restart
     integer :: restart
-     
+    double precision :: restart_time
+
   end type problem_type
 
 end module problem_class

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -33,7 +33,7 @@ module problem_class
   type ox_type
     integer :: ntout=0, nrup=-1
     integer :: count, dyn_count, dyn_stat, i_ox_dyn, i_ox_seq, seq_count
-    integer :: nwout, nwout_dyn, nxout, nxout_dyn
+    integer :: nwout, nwout_dyn, nwout_last, nxout, nxout_dyn, nx_outlast
     double precision :: pot_pre
     character(len=256) :: header
     character(len=16), dimension(:), allocatable :: fmt

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -107,7 +107,7 @@ module problem_class
     ! Containers for local and global quantities
     type(optr), dimension(:), allocatable :: objects_glob, objects_loc
     ! Number of objects in the containers
-    integer :: nobj=9
+    integer :: nobj=10
 
     ! Basic variables
     ! NOTE: if theta2 needs to be in output sequence, add here

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -162,6 +162,10 @@ module problem_class
     type (rk45_type) :: rk45
     type (rk45_2_type) :: rk45_2
     type (test_type) :: test
+
+    ! Restart
+    integer :: restart
+     
   end type problem_type
 
 end module problem_class

--- a/qdyn/problem_class.f90
+++ b/qdyn/problem_class.f90
@@ -1,4 +1,4 @@
-!define problem
+!define problemmesh_type
 
 module problem_class
 
@@ -119,7 +119,13 @@ module problem_class
     double precision, dimension(:), allocatable :: theta2, alpha
     double precision, pointer ::  tau_max(:) => null(), t_rup(:) => null(), &
                                   v_max(:) => null(), t_vmax(:) => null()
+    ! Potency variables
     double precision, pointer :: pot => null(), pot_rate => null()
+  
+    ! Fault label variables
+    !double precision, dimension(:), allocatable :: unique_labels, freq_labels, cumsum_freq_labels
+    ! Fault potency variables
+    double precision, dimension(:), allocatable :: pot_fault, pot_rate_fault
    ! Boundary conditions
     integer :: i_sigma_cpl=0, finite=0
    ! Friction properties
@@ -165,7 +171,10 @@ module problem_class
 
     ! Restart
     integer :: restart
-    double precision :: restart_time
+    double precision :: restart_time, restart_slip
+
+    ! Number of fault labels
+    integer :: nfault
 
   end type problem_type
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -97,7 +97,8 @@ class qdyn:
         set_dict["TPER"] = 31536000			# Period of additional time-dependent oscillatory shear stress loading [s]
         set_dict["APER"] = 0				# Amplitude of additional time-dependent oscillatory shear stress loading [Pa]
         set_dict["DIP_W"] = 90				# Fault dip in 3D
-        set_dict["Z_CORNER"] = 0			# 3D
+        set_dict["Z_CORNER"] = 0			# 3D (Base of the fault)
+        set_dict["FAULT_LABEL"] = 1         # Label of the fault (int) 
 
         # Optional simulation features
         set_dict["FEAT_STRESS_COUPL"] = 0	# Normal stress coupling
@@ -206,6 +207,7 @@ class qdyn:
 
         set_dict["NPROC"] = 1				# Number of processors, default 1 = serial (no MPI)
         set_dict["MPI_PATH"] = "/usr/local/bin/mpirun"   # Path to MPI executable
+
 
         self.set_dict = set_dict
 
@@ -325,6 +327,9 @@ class qdyn:
             mesh_dict["X"] = X.ravel()
             mesh_dict["Y"] = Y.ravel()
             mesh_dict["Z"] = settings["Z_CORNER"] + mesh_dict["Y"]*np.tan(theta)
+        
+        # Populate mesh with fault labels
+        mesh_dict["FAULT_LABEL"] = np.ones(N)*settings["FAULT_LABEL"]
 
         self.mesh_dict.update(mesh_dict)
         self.mesh_rendered = True
@@ -586,7 +591,7 @@ class qdyn:
 
             # Add mesh grid location information
             for i in range(nloc):
-                input_str += "%.15g %.15g %.15g %.15g\n" % (mesh["X"][iloc[i]], mesh["Y"][iloc[i]], mesh["Z"][iloc[i]], mesh["DIP_W"][iloc[i]])
+                input_str += "%.15g %.15g %.15g %.15g %.15g\n" % (mesh["X"][iloc[i]], mesh["Y"][iloc[i]], mesh["Z"][iloc[i]], mesh["DIP_W"][iloc[i]], mesh["FAULT_LABEL"][iloc[i]])
 
             nnLocal += settings["NX"]*nwLocal[iproc]
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -52,7 +52,7 @@ class qdyn:
     qdyn_path = os.path.abspath(
         os.path.join(os.path.realpath(__file__), os.pardir)
     )
-    qdyn_path = "/home/crodriguezpiceda/buildqdyn/qdyn_2_4_0/"
+    qdyn_path = "/home/crodriguezpiceda/buildqdyn/qdyn_lastox/"
     # Working directory can be kept empty, except for special cases
     work_dir = ""
     # Flag for using the bash environment in Windows 10

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -662,7 +662,7 @@ class qdyn:
     # Read QDYN output data
     def read_output(self, mirror=False, read_ot=True, filename_ot="output_ot",
                     filename_vmax="output_vmax", read_ox=True,
-                    filename_ox="output_ox", read_ox_dyn=False,):
+                    filename_ox="output_ox", read_ox_dyn=False, filename_ox_last="output_ox_last", read_ox_last=False):
 
         # Output file contents depends on the requested features
         # Time series (ot)
@@ -712,6 +712,7 @@ class qdyn:
             self.ot_vmax = None
             self.N_iot = 0
 
+        # Standard snapshots
         if read_ox:
 
             # Read snapshot output
@@ -731,6 +732,27 @@ class qdyn:
         else:
             self.ox = None
 
+        # Last snapshot
+        if read_ox_last == True:
+
+            # Read snapshot output
+            data_ox_last = read_csv(filename_ox_last, header=None, names=quants_ox, delim_whitespace=True, comment="#")
+
+            # Store snapshot data in self.ox
+            self.ox_last = data_ox_last
+
+            # Sanitise output (check for near-infinite numbers, etc.)
+            self.ox_last = self.ox_last.apply(pd.to_numeric, errors="coerce")
+
+            # If free surface was generated manually (i.e. without FINITE = 2 or 3),
+            # take only half data set (symmetric around first element)
+            if mirror == True:
+                data_ox_last = data_ox_last.loc[(data_ox_last["x"] > 0)]
+                self.ox_last = data_ox_last
+        else:
+            self.ox_last = None
+
+        # Dynamic snapshot
         if read_ox_dyn == True:
 
             ox_dyn_files_pre = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_pre")])

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -103,6 +103,7 @@ class qdyn:
         set_dict["FEAT_STRESS_COUPL"] = 0	# Normal stress coupling
         set_dict["FEAT_TP"] = 0				# Thermal pressurisation
         set_dict["FEAT_LOCALISATION"] = 0	# Gouge zone localisation of strain (CNS only)
+        set_dict["FEAT_RESTART"] = 0        # Restart simulation from last snapshot of a previous simulation
 
         # Rate-and-state friction parameters
         set_dict["SET_DICT_RSF"] = {
@@ -472,6 +473,10 @@ class qdyn:
         Nprocs = settings["NPROC"]
         delimiter = "    "
 
+        # Add restart
+        restart = settings["FEAT_RESTART"]
+
+
         # Define chunk size for each processor
         nwLocal = (settings["NW"]//Nprocs)*np.ones(Nprocs, dtype=int)
         nwLocal[Nprocs-1] += settings["NW"] % Nprocs
@@ -494,6 +499,7 @@ class qdyn:
             # Start building the contents of our QDYN input file (input_str)
             input_str = ""
             input_str += "%u%s meshdim\n" % (settings["MESHDIM"], delimiter)
+            
 
             # Input specific to 3D faults
             if settings["MESHDIM"] == 2:
@@ -521,6 +527,10 @@ class qdyn:
             # Some more general settings
             # Note that i_sigma_law is replaced by the feature stress_coupling, but is kept for compatibility
             input_str += "%u%s i_sigma_law\n" % (settings["SIGMA_CPL"], delimiter)
+
+            # Check RESTART ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            input_str += "%u%s restart\n" % (settings["FEAT_RESTART"], delimiter)
+
             # If the CNS model is used, define the number of creep mechanisms
             if settings["FRICTION_MODEL"] == "CNS":
                 # Raise an error when the default value has not been overwritten

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -886,24 +886,36 @@ class qdyn:
         # If fault data is requested
 
         if read_fault:
-
+            
+            # Number of faults
             N_faults = self.set_dict["N_FAULTS"]
+
+            # List where each element is a DataFrame with the output of one fault
             self.fault = [None] * N_faults
 
             # Check output directory
             if path_output!=None:
                 filename_fault = path_output + filename_fault 
-            for n in np.arange(1,N_faults+1):
-                col_list = [0, n, n + N_faults, n + 2*N_faults] # Use columns of one fault only
-                print(n)
+
+            # Number of columns with fault output (excluding time)
+            N_cols = 3 * N_faults
+
+            # Counter of fault number for loop
+            n = 0
+            
+            # Read the output file in groups of columns corresponding to each fault
+            for i in range(1,N_cols+1,3):
+                # Column list for one fault (time, potency, potency rate and delta slip)
+                col_list = [0] + list(range(i, i+3))
                 print(col_list)
-                self.fault[n-1] = read_csv(
+                # Read output file
+                self.fault[n] = read_csv(
                 filename_fault, header=None, skiprows=nheaders_fault, usecols=col_list,
                 names=quants_fault, delim_whitespace=True
                 )
                 # Discard duplicate rows from duplicate time-steps
-                self.fault[n-1] = self.fault[n-1].drop_duplicates(subset=["t"], keep="first") 
-
+                self.fault[n] = self.fault[n].drop_duplicates(subset=["t"], keep="first")
+                n =+1
         return True
 
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -487,6 +487,9 @@ class qdyn:
         Nprocs = settings["NPROC"]
         delimiter = "    "
 
+        # Check if multiple processors have been assigned for 0D and 1D faults
+        if settings["MESHDIM"]!=2 and settings["NPROC"]!=1:
+            raise ValueError("Multiple processors are compatible only with simulation dimensionality=2") 
 
         # Define chunk size for each processor
         nwLocal = (settings["NW"]//Nprocs)*np.ones(Nprocs, dtype=int)

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -660,7 +660,10 @@ class qdyn:
 
 
     # Read QDYN output data
-    def read_output(self, mirror=False, read_ot=True, filename_ot="output_ot",
+    # This modified function allows to retrieve the outputs from a folder other than the one of the python script
+    # It can also read the output of the last snapshot
+
+    def read_output(self, mirror=False, path_output=None, read_ot=True, filename_ot="output_ot",
                     filename_vmax="output_vmax", read_ox=True,
                     filename_ox="output_ox", read_ox_dyn=False, filename_ox_last="output_ox_last", read_ox_last=False):
 
@@ -696,11 +699,21 @@ class qdyn:
             self.ot = [None] * N_iot
 
             for n, i in enumerate(iot):
+
+                # Check output directory
+                if path_output!=None:
+                    filename_ot = path_output + filename_ot
+
                 filename_iot = "%s_%i" % (filename_ot, i)
+
                 self.ot[n] = read_csv(
                     filename_iot, header=None, skiprows=nheaders_ot,
                     names=quants_ot, delim_whitespace=True
                 )
+
+            # Check output directory
+            if path_output!=None:
+                filename_vmax = path_output + filename_vmax
 
             self.ot_vmax = read_csv(
                 filename_vmax, header=None, skiprows=nheaders_vmax,
@@ -716,6 +729,10 @@ class qdyn:
         if read_ox:
 
             # Read snapshot output
+            # Check output directory
+            if path_output!= None:
+                filename_ox= path_output + filename_ox
+
             data_ox = read_csv(filename_ox, header=None, names=quants_ox, delim_whitespace=True, comment="#")
 
             # Store snapshot data in self.ox
@@ -736,6 +753,9 @@ class qdyn:
         if read_ox_last == True:
 
             # Read snapshot output
+            # Check output directory
+            if path_output!= None:
+                filename_ox_last = path_output + filename_ox_last
             data_ox_last = read_csv(filename_ox_last, header=None, names=quants_ox, delim_whitespace=True, comment="#")
 
             # Store snapshot data in self.ox
@@ -755,9 +775,15 @@ class qdyn:
         # Dynamic snapshot
         if read_ox_dyn == True:
 
-            ox_dyn_files_pre = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_pre")])
-            ox_dyn_files_post = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_post")])
-            ox_dyn_files_rup = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_max")])
+            # Check directory
+            if path_output != None:
+                ox_dyn_files_pre = np.array([file for file in os.listdir(path_output) if file.startswith("output_dyn_pre")])
+                ox_dyn_files_post = np.array([file for file in os.listdir(path_output) if file.startswith("output_dyn_post")])
+                ox_dyn_files_rup = np.array([file for file in os.listdir(path_output) if file.startswith("output_dyn_max")])
+            else:                
+                ox_dyn_files_pre = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_pre")])
+                ox_dyn_files_post = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_post")])
+                ox_dyn_files_rup = np.array([file for file in os.listdir(".") if file.startswith("output_dyn_max")])
 
             # Read snapshot output
             data_ox_dyn_pre = [None] * len(ox_dyn_files_pre)
@@ -795,6 +821,7 @@ class qdyn:
             self.ox_dyn_pre = data_ox_dyn_pre
             self.ox_dyn_post = data_ox_dyn_post
             self.ox_dyn_rup = data_ox_dyn_rup
+            
 
         return True
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -104,6 +104,7 @@ class qdyn:
         set_dict["FEAT_TP"] = 0				# Thermal pressurisation
         set_dict["FEAT_LOCALISATION"] = 0	# Gouge zone localisation of strain (CNS only)
         set_dict["FEAT_RESTART"] = 0        # Restart simulation from last snapshot of a previous simulation
+        set_dict["RESTART_TIME"] = 0        # Restart time of the simulation [s] 
 
         # Rate-and-state friction parameters
         set_dict["SET_DICT_RSF"] = {
@@ -475,6 +476,7 @@ class qdyn:
 
         # Add restart
         restart = settings["FEAT_RESTART"]
+        restart_time = settings["RESTART_TIME"]
 
 
         # Define chunk size for each processor
@@ -530,6 +532,7 @@ class qdyn:
 
             # Check RESTART ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             input_str += "%u%s restart\n" % (settings["FEAT_RESTART"], delimiter)
+            input_str += "%.15g%s restart time\n" % (settings["RESTART_TIME"], delimiter)
 
             # If the CNS model is used, define the number of creep mechanisms
             if settings["FRICTION_MODEL"] == "CNS":

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -52,6 +52,7 @@ class qdyn:
     qdyn_path = os.path.abspath(
         os.path.join(os.path.realpath(__file__), os.pardir)
     )
+    qdyn_path = "/home/crodriguezpiceda/buildqdyn/qdyn_2_4_0/"
     # Working directory can be kept empty, except for special cases
     work_dir = ""
     # Flag for using the bash environment in Windows 10

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -684,20 +684,20 @@ class qdyn:
         # Output file contents depends on the requested features
         # Time series (ot)
         nheaders_ot = 4
-        quants_ot = ("t", "potcy", "pot_rate", "v", "theta", "tau", "dtau_dt", "slip", "sigma")
+        quants_ot = ("t", "potcy", "pot_rate", "v", "theta", "tau", "dtau_dt", "slip", "sigma", "fault_label")
         if self.set_dict["FEAT_TP"] == 1:
             nheaders_ot += 1
             quants_ot += ("P", "T")
 
         # Vmax
         nheaders_vmax = 2
-        quants_vmax = ("t", "ivmax", "v", "theta", "tau", "dtau_dt", "slip", "sigma")
+        quants_vmax = ("t", "ivmax", "v", "theta", "tau", "dtau_dt", "slip", "sigma", "fault_label")
         if self.set_dict["FEAT_TP"] == 1:
             nheaders_vmax += 1
             quants_vmax += ("P", "T")
 
         # Standard snapshots (ox)
-        quants_ox = ("t", "x", "y", "z", "v", "theta", "tau", "tau_dot", "slip", "sigma")
+        quants_ox = ("t", "x", "y", "z", "v", "theta", "tau", "tau_dot", "slip", "sigma", "fault_label")
         if self.set_dict["FEAT_TP"] == 1:
             quants_ox += ("P", "T")
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -862,6 +862,12 @@ class qdyn:
 
 
 
-
+    # Return time of last snapshot of a simulation
+    #  (used when restarting a simulation from a previous model)
+    def restart_time(self):
+        last_ox = open("output_ox_last", "r")
+        line = last_ox.readlines()
+        last_time = float(line[2].split()[0])
+        return last_time
 
 

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -723,10 +723,6 @@ class qdyn:
         
         # Fault time-series
         nheaders_fault = 2
-        # 1=t  2=pot_1 2=pot_2 3=pot_rate_1 3=pot_rate_2 4=slip_dt_1 4=slip_dt_2
-        #quants_pot = ["pot_" + str(n) for n in np.arange(1,nfaults+1)]
-        #quants_potrate = ["pot_rate_" + str(n) for n in np.arange(1,nfaults+1)]
-        #quants_slipdt = ["slip_dt_" + str(n) for n in np.arange(1,nfaults+1)]
         quants_fault = ("t", "potcy_fault", "pot_rate_fault", "slip_dt_fault")
 
         # If time series data is requested
@@ -907,7 +903,7 @@ class qdyn:
             for i in range(1,N_cols+1,3):
                 # Column list for one fault (time, potency, potency rate and delta slip)
                 col_list = [0] + list(range(i, i+3))
-                print(col_list)
+
                 # Read output file
                 self.fault[n] = read_csv(
                 filename_fault, header=None, skiprows=nheaders_fault, usecols=col_list,

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -474,10 +474,6 @@ class qdyn:
         Nprocs = settings["NPROC"]
         delimiter = "    "
 
-        # Add restart
-        restart = settings["FEAT_RESTART"]
-        restart_time = settings["RESTART_TIME"]
-
 
         # Define chunk size for each processor
         nwLocal = (settings["NW"]//Nprocs)*np.ones(Nprocs, dtype=int)

--- a/qdyn/pyqdyn.py
+++ b/qdyn/pyqdyn.py
@@ -52,7 +52,7 @@ class qdyn:
     qdyn_path = os.path.abspath(
         os.path.join(os.path.realpath(__file__), os.pardir)
     )
-    qdyn_path = "/home/crodriguezpiceda/buildqdyn/qdyn_lastox/"
+    qdyn_path = "/home/crodriguezpiceda/buildqdyn/qdyn_faultlabel/"
     # Working directory can be kept empty, except for special cases
     work_dir = ""
     # Flag for using the bash environment in Windows 10

--- a/qdyn/utils/post_processing/plot_functions.py
+++ b/qdyn/utils/post_processing/plot_functions.py
@@ -15,7 +15,7 @@ figsize = (9, 8)
 
 def timeseries(ot, ot_vmax):
 
-    fig, axes = plt.subplots(nrows=3, ncols=1, figsize=figsize)
+    fig, axes = plt.subplots(nrows=4, ncols=1, figsize=figsize)
 
     axes[0].plot(ot["t"] / t_year, ot["tau"])
     axes[0].set_ylabel("tau [Pa]")
@@ -23,10 +23,13 @@ def timeseries(ot, ot_vmax):
     axes[1].plot(ot["t"] / t_year, ot["theta"])
     axes[1].set_ylabel("state [s]")
 
-    axes[2].plot(ot_vmax["t"] / t_year, ot_vmax["v"])
-    axes[2].set_ylabel("max v [m/s]")
-    axes[2].set_xlabel("time [yr]")
-    axes[2].set_yscale("log")
+    axes[2].plot(ot["t"] / t_year, ot["sigma"])
+    axes[2].set_ylabel("sigma [Pa]")
+
+    axes[3].plot(ot_vmax["t"] / t_year, ot_vmax["v"])
+    axes[3].set_ylabel("max v [m/s]")
+    axes[3].set_xlabel("time [yr]")
+    axes[3].set_yscale("log")
 
     plt.tight_layout()
     plt.show()

--- a/qdyn/utils/post_processing/plot_functions.py
+++ b/qdyn/utils/post_processing/plot_functions.py
@@ -1,3 +1,7 @@
+"""
+Useful functions for post-processing (plotting) 
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import animation, rc


### PR DESCRIPTION
The idea of this implementation is to simplify the workflow to restart a simulation without having to starting at 0s. Before, if we wanted to the restart a model, we needed different folders for the different runs; otherwise, the outputs would be overwritten with each new run. This would mean having multiple output files spread over multiple folders, which might be cumbersome to post-process. The spirit of this new implementation is to have the flexibility to choose between starting a simulation at 0s (aka “scratch model”) and at any time-step from a previous simula-tion (aka “restart model”). When restarting a model, all the outputs are appended at the end of the files of the previous simulation instead of rewritten, which allows the user to have a unique folder with all the model runs.

Major changes introduced:
- New outputs:
 1. Log file (`log`) that stores time-steps from all simulations. Convenient way to check if the restart function is working properly. All simulations time-steps are stored in one file, instead of having only different log files for each submission script.
2. Last snapshot with the full mesh resolution (`output_lastox`). This is going to be used as input (`sigma`, `V_0` and `Theta_0`) for the initial conditions of the subsequent simulation.
-	The python function `p.read_output` in the wrapper is also able to read the output of the last snapshot. Besides, the function can read output files from a folder other than the one of the script. These functionalities are convenient when setting the input file of the restart model and for postprocessing, respectively.
-	Three new flags where introduced when setting the dictionary for the initial mesh.
  1. `FEAT_RESTART`: This flag indicates if the simulation is a scratch (`FEAT_RESTART`=0) or a restart model (`FEAT_RESTART`=1). The default value is `FEAT_RESTART = 0`. 
  2. `RESTART_TIME`: the time of restart of the model. It is important to recall that this time-step of restart is the last snapshot of the previous simulation, which might or not be the actual last-time step, depending on the value of `set_dict[“NTOUT”]` (save output every N timesteps). The default value is `RESTART_TIME= 0`. To quickly get this value, I introduced a function in the python wrapper called `restart_time()`
  3. `RESTART_SLIP`: the slip at the time of restarting of the model. To quickly get this value, I introduced a function in the python wrapper called `restart_slip()`. The default value is `RESTART_SLIP= 0`
-	The input file `qdyn.in` also has a new line indicating if the model is restarting or not, and the time and slip values at which the model should restart. This information is latter used in the `output` module in the source code.   
-	I added a tutorial (`single_asperity_3D_restart.ipynb`) with an example on how to restart a model (using as initial model the single asperity 3D case). This notebook is found in the folder with the examples.
